### PR TITLE
fix minor sentry errors

### DIFF
--- a/src/assets/svg/AnimatedCameraIcon.tsx
+++ b/src/assets/svg/AnimatedCameraIcon.tsx
@@ -1,67 +1,46 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import {COLORS} from '@constants/colors';
 import * as React from 'react';
-import {ColorValue} from 'react-native';
-import Animated, {
-  createAnimatedPropAdapter,
-  processColor,
-  useAnimatedProps,
-} from 'react-native-reanimated';
+import {ViewStyle} from 'react-native';
+import Animated, {AnimatedStyleProp} from 'react-native-reanimated';
 import Svg, {Path} from 'react-native-svg';
 import {rem} from 'rn-units';
 
-const AnimatedPath = Animated.createAnimatedComponent(Path);
+const AnimatedSvg = Animated.createAnimatedComponent(Svg);
 
 type AnimatedCameraIconProps = {
-  animatedColor: Animated.SharedValue<ColorValue>;
   width?: number;
   height?: number;
+  style?: AnimatedStyleProp<ViewStyle>;
 };
 
 export const AnimatedCameraIcon = ({
   width = rem(20),
   height = rem(20),
-  animatedColor,
+  style,
 }: AnimatedCameraIconProps) => {
-  const animatedProps = useAnimatedProps(
-    () => {
-      return {
-        stroke: animatedColor.value,
-      };
-    },
-    [],
-    createAnimatedPropAdapter(
-      props => {
-        if (props?.stroke) {
-          props.stroke = {
-            type: 0,
-            payload:
-              (typeof props.stroke === 'string' ||
-                typeof props.stroke === 'number') &&
-              processColor(props.stroke),
-          };
-        }
-      },
-      ['stroke'],
-    ),
-  );
-
   return (
-    <Svg width={width} height={height} viewBox="0 0 20 20" fill="none">
-      <AnimatedPath
+    <AnimatedSvg
+      width={width}
+      height={height}
+      viewBox="0 0 20 20"
+      fill="none"
+      style={style}>
+      <Path
         d="M12.0833 3.3335H7.91666L5.83332 5.8335H3.33332C2.8913 5.8335 2.46737 6.00909 2.15481 6.32165C1.84225 6.63421 1.66666 7.05814 1.66666 7.50016V15.0002C1.66666 15.4422 1.84225 15.8661 2.15481 16.1787C2.46737 16.4912 2.8913 16.6668 3.33332 16.6668H16.6667C17.1087 16.6668 17.5326 16.4912 17.8452 16.1787C18.1577 15.8661 18.3333 15.4422 18.3333 15.0002V7.50016C18.3333 7.05814 18.1577 6.63421 17.8452 6.32165C17.5326 6.00909 17.1087 5.8335 16.6667 5.8335H14.1667L12.0833 3.3335Z"
         strokeWidth="1.6"
         strokeLinecap="round"
         strokeLinejoin="round"
-        animatedProps={animatedProps}
+        stroke={COLORS.primaryDark}
       />
-      <AnimatedPath
+      <Path
         d="M10 13.3335C11.3807 13.3335 12.5 12.2142 12.5 10.8335C12.5 9.45278 11.3807 8.3335 10 8.3335C8.61929 8.3335 7.5 9.45278 7.5 10.8335C7.5 12.2142 8.61929 13.3335 10 13.3335Z"
-        animatedProps={animatedProps}
         strokeWidth="1.6"
         strokeLinecap="round"
         strokeLinejoin="round"
+        stroke={COLORS.primaryDark}
       />
-    </Svg>
+    </AnimatedSvg>
   );
 };

--- a/src/components/AnimatedSplash/index.tsx
+++ b/src/components/AnimatedSplash/index.tsx
@@ -2,6 +2,7 @@
 
 import {LottieView} from '@components/LottieView';
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {LottieAnimations} from '@lottie';
 import {AppCommonActions} from '@store/modules/AppCommon/actions';
 import {
@@ -12,7 +13,6 @@ import React, {useCallback, useState} from 'react';
 import {useEffect} from 'react';
 import {StyleSheet, View} from 'react-native';
 import {useDispatch, useSelector} from 'react-redux';
-import {screenWidth} from 'rn-units';
 
 export const AnimatedSplash = () => {
   const appInitState = useSelector(appInitStateSelector);
@@ -61,7 +61,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   animation: {
-    width: screenWidth,
-    height: screenWidth * 2.165,
+    width: windowWidth,
+    height: windowWidth * 2.165,
   },
 });

--- a/src/components/Avatar/hooks/usePickImage.ts
+++ b/src/components/Avatar/hooks/usePickImage.ts
@@ -2,6 +2,7 @@
 
 import {FULL_SCREEN_IMAGE_SIZE} from '@constants/images';
 import {logError} from '@services/logging';
+import {checkProp} from '@utils/guards';
 import ImagePicker, {
   Image,
   Options,
@@ -15,22 +16,40 @@ export const usePickImage = ({
   onImageSelected: (image: Image) => void;
   options?: Options;
 }) => {
-  const openPicker = (mode: 'gallery' | 'camera') =>
-    ImagePicker[mode === 'gallery' ? 'openPicker' : 'openCamera']({
-      width: FULL_SCREEN_IMAGE_SIZE,
-      height: FULL_SCREEN_IMAGE_SIZE,
-      mediaType: 'photo',
-      cropping: true,
-      forceJpg: true,
-      includeBase64: false,
-      includeExif: false,
-      ...options,
-    })
-      .then(onImageSelected)
-      .catch(error => {
-        if ((error.code as PickerErrorCode) !== 'E_PICKER_CANCELLED') {
-          logError(error);
-        }
+  const openPicker = async (mode: 'gallery' | 'camera') => {
+    try {
+      const selectedImage = await ImagePicker[
+        mode === 'gallery' ? 'openPicker' : 'openCamera'
+      ]({
+        mediaType: 'photo',
+        cropping: false,
+        forceJpg: true,
+        includeBase64: false,
+        includeExif: false,
+        ...options,
       });
+      /**
+       * Call openPicker/openCamera and openCropper separately
+       * so library converts selected image to jpg before cropping.
+       * This workaround saves from variety of errors on android (e.g. when picking webp)
+       */
+      const croppedImage = await ImagePicker.openCropper({
+        mediaType: 'photo',
+        path: selectedImage.path,
+        width: FULL_SCREEN_IMAGE_SIZE,
+        height: FULL_SCREEN_IMAGE_SIZE,
+        includeBase64: false,
+        includeExif: false,
+      });
+      onImageSelected(croppedImage);
+    } catch (error) {
+      if (
+        checkProp(error, 'code') &&
+        (error.code as PickerErrorCode) !== 'E_PICKER_CANCELLED'
+      ) {
+        logError(error);
+      }
+    }
+  };
   return {openPicker, onImageSelected};
 };

--- a/src/components/LinesBackground/index.tsx
+++ b/src/components/LinesBackground/index.tsx
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import {windowWidth} from '@constants/styles';
 import {Images} from '@images';
 import React from 'react';
 import {Image, ImageStyle, StyleProp, StyleSheet} from 'react-native';
-import {screenWidth} from 'rn-units';
 
 type Props = {
   style?: StyleProp<ImageStyle>;
@@ -24,7 +24,7 @@ export const LinesBackground = ({style}: Props) => {
 const styles = StyleSheet.create({
   background: {
     position: 'absolute',
-    width: screenWidth,
-    height: screenWidth * RATIO,
+    width: windowWidth,
+    height: windowWidth * RATIO,
   },
 });

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
-import {StyleSheet} from 'react-native';
+import {Dimensions, StyleSheet} from 'react-native';
 import {isIOS, rem, screenHeight} from 'rn-units';
 
 export const SCREEN_SIDE_OFFSET = rem(20);
@@ -35,5 +35,7 @@ export const MIDDLE_BUTTON_HIT_SLOP = {
   bottom: 12,
   right: 32,
 };
+
+export const windowWidth = Dimensions.get('window').width;
 
 export const smallHeightDevice = screenHeight < 680;

--- a/src/screens/AuthFlow/ConfirmEmailLink/components/Header/index.tsx
+++ b/src/screens/AuthFlow/ConfirmEmailLink/components/Header/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {useTopOffsetStyle} from '@hooks/useTopOffsetStyle';
 import {Images} from '@images';
 import {FolderIcon} from '@svg/FilderIcon';
@@ -8,7 +9,7 @@ import {t} from '@translations/i18n';
 import {font} from '@utils/styles';
 import React from 'react';
 import {Image, StyleSheet, Text, View} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export const Header = () => {
   const topOffset = useTopOffsetStyle();
@@ -31,8 +32,8 @@ export const Header = () => {
 
 const styles = StyleSheet.create({
   background: {
-    width: screenWidth,
-    height: (screenWidth * 368) / 375,
+    width: windowWidth,
+    height: (windowWidth * 368) / 375,
     position: 'absolute',
     bottom: 0,
   },

--- a/src/screens/AuthFlow/ConfirmPhone/components/Header/index.tsx
+++ b/src/screens/AuthFlow/ConfirmPhone/components/Header/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {useTopOffsetStyle} from '@hooks/useTopOffsetStyle';
 import {Images} from '@images';
 import {ChatBubbleIcon} from '@svg/ChatBubbleIcon';
@@ -8,7 +9,7 @@ import {t} from '@translations/i18n';
 import {font} from '@utils/styles';
 import React from 'react';
 import {Image, StyleSheet, Text, View} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export const Header = () => {
   const topOffset = useTopOffsetStyle();
@@ -35,8 +36,8 @@ export const Header = () => {
 
 const styles = StyleSheet.create({
   background: {
-    width: screenWidth,
-    height: (screenWidth * 368) / 375,
+    width: windowWidth,
+    height: (windowWidth * 368) / 375,
     position: 'absolute',
     bottom: 0,
   },

--- a/src/screens/AuthFlow/InvalidLink/components/Header/index.tsx
+++ b/src/screens/AuthFlow/InvalidLink/components/Header/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {useTopOffsetStyle} from '@hooks/useTopOffsetStyle';
 import {Images} from '@images';
 import {AttentionIcon} from '@svg/AttentionIcon';
@@ -8,7 +9,7 @@ import {t} from '@translations/i18n';
 import {font} from '@utils/styles';
 import React from 'react';
 import {Image, StyleSheet, Text, View} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export const Header = () => {
   const topOffset = useTopOffsetStyle();
@@ -33,8 +34,8 @@ export const Header = () => {
 
 const styles = StyleSheet.create({
   background: {
-    width: screenWidth,
-    height: (screenWidth * 368) / 375,
+    width: windowWidth,
+    height: (windowWidth * 368) / 375,
     position: 'absolute',
     bottom: 0,
   },

--- a/src/screens/AuthFlow/ResetPasswordLink/components/Header/index.tsx
+++ b/src/screens/AuthFlow/ResetPasswordLink/components/Header/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {useTopOffsetStyle} from '@hooks/useTopOffsetStyle';
 import {Images} from '@images';
 import {FolderIcon} from '@svg/FilderIcon';
@@ -8,7 +9,7 @@ import {t} from '@translations/i18n';
 import {font} from '@utils/styles';
 import React from 'react';
 import {Image, StyleSheet, Text, View} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export const Header = () => {
   const topOffset = useTopOffsetStyle();
@@ -31,8 +32,8 @@ export const Header = () => {
 
 const styles = StyleSheet.create({
   background: {
-    width: screenWidth,
-    height: (screenWidth * 368) / 375,
+    width: windowWidth,
+    height: (windowWidth * 368) / 375,
     position: 'absolute',
     bottom: 0,
   },

--- a/src/screens/AuthFlow/SignIn/components/Header/index.tsx
+++ b/src/screens/AuthFlow/SignIn/components/Header/index.tsx
@@ -2,6 +2,7 @@
 
 import {BackButton} from '@components/BackButton';
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {useTopOffsetStyle} from '@hooks/useTopOffsetStyle';
 import {Images} from '@images';
 import {AuthStackParamList} from '@navigation/Auth';
@@ -12,7 +13,7 @@ import {t} from '@translations/i18n';
 import {font} from '@utils/styles';
 import React from 'react';
 import {Image, StyleSheet, Text, View} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export const Header = () => {
   const topOffset = useTopOffsetStyle();
@@ -50,8 +51,8 @@ export const Header = () => {
 
 const styles = StyleSheet.create({
   background: {
-    width: screenWidth,
-    height: (screenWidth * 368) / 375,
+    width: windowWidth,
+    height: (windowWidth * 368) / 375,
     position: 'absolute',
     bottom: 0,
   },

--- a/src/screens/AuthFlow/SignIn/components/SocialButtons/index.tsx
+++ b/src/screens/AuthFlow/SignIn/components/SocialButtons/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {SocialButton} from '@screens/AuthFlow/SignIn/components/SocialButtons/components/SocialButton';
+import {isPlayServicesAvailable} from '@services/firebase';
 import {AccountActions} from '@store/modules/Account/actions';
 import {AppleIcon} from '@svg/AppleIcon';
 import {FacebookIcon} from '@svg/FacebookIcon';
@@ -25,12 +26,14 @@ export const SocialButtons = () => {
         />
       ) : null}
 
-      <SocialButton
-        onPress={() =>
-          dispatch(AccountActions.SIGN_IN_SOCIAL.START.create('google'))
-        }
-        Icon={GoogleIcon}
-      />
+      {isPlayServicesAvailable && (
+        <SocialButton
+          onPress={() =>
+            dispatch(AccountActions.SIGN_IN_SOCIAL.START.create('google'))
+          }
+          Icon={GoogleIcon}
+        />
+      )}
 
       {
         // // TODO: temp facebook disabling until the provider is ready

--- a/src/screens/AuthFlow/SignIn/index.tsx
+++ b/src/screens/AuthFlow/SignIn/index.tsx
@@ -73,7 +73,7 @@ export const SignIn = () => {
           </View>
           {!isResetPassword && <SocialButtons />}
         </View>
-        <PrivacyTerms />
+        <PrivacyTerms containerStyle={styles.privacy} />
       </ScrollView>
       {isSocialAuthLoading && <FullScreenLoading />}
     </KeyboardAvoider>
@@ -98,5 +98,9 @@ const styles = StyleSheet.create({
   form: {
     marginTop: rem(20),
     marginHorizontal: rem(20),
+  },
+  privacy: {
+    marginTop: rem(24),
+    marginBottom: rem(12),
   },
 });

--- a/src/screens/HomeFlow/Home/components/Header/components/MenuButton.tsx
+++ b/src/screens/HomeFlow/Home/components/Header/components/MenuButton.tsx
@@ -4,7 +4,7 @@ import {Badge} from '@components/Badge';
 import {Touchable} from '@components/Touchable';
 import {COLORS} from '@constants/colors';
 import {LINKS} from '@constants/links';
-import {MIDDLE_BUTTON_HIT_SLOP} from '@constants/styles';
+import {MIDDLE_BUTTON_HIT_SLOP, windowWidth} from '@constants/styles';
 import {HomeTabStackParamList, MainStackParamList} from '@navigation/Main';
 import {useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
@@ -18,7 +18,7 @@ import {t} from '@translations/i18n';
 import {openLinkWithInAppBrowser} from '@utils/device';
 import React, {memo, useMemo, useRef} from 'react';
 import {StyleSheet, TouchableOpacity, View} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export const MenuButton = memo(() => {
   const navigation =
@@ -81,7 +81,7 @@ export const MenuButton = memo(() => {
       navigation.navigate('ContextualMenu', {
         coords: {
           top: y + height + rem(16),
-          right: screenWidth - x - rem(16),
+          right: windowWidth - x - rem(16),
         },
         buttons,
       });

--- a/src/screens/HomeFlow/Home/components/Header/components/hooks/useMenuButtonWalkthrough.tsx
+++ b/src/screens/HomeFlow/Home/components/Header/components/hooks/useMenuButtonWalkthrough.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
-import {commonStyles} from '@constants/styles';
+import {commonStyles, windowWidth} from '@constants/styles';
 import {
   Menu,
   ROUNDED_TRIANGLE_OFFSET,
@@ -12,7 +12,7 @@ import {WalkthroughStepKey} from '@store/modules/Walkthrough/types';
 import {CandyBoxMenuIcon} from '@svg/CandyBoxMenuIcon';
 import React, {useRef} from 'react';
 import {StyleSheet, View} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 const MENU_ICON_SIZE = rem(24);
 const MENU_ICON_CONTAINER_SIZE = rem(40);
@@ -60,7 +60,7 @@ export const useMenuButtonWalkthrough = ({
                     styles.mainContainer,
                     {
                       paddingRight:
-                        screenWidth -
+                        windowWidth -
                         measurements.pageX -
                         MENU_ICON_SIZE -
                         EXTRA_PADDING,
@@ -102,7 +102,7 @@ export const useMenuButtonWalkthrough = ({
 };
 
 const styles = StyleSheet.create({
-  mainContainer: {width: screenWidth, flexDirection: 'row'},
+  mainContainer: {width: windowWidth, flexDirection: 'row'},
   boxMenuOuterContainer: {
     flex: 1,
     alignItems: 'flex-end',

--- a/src/screens/HomeFlow/Home/components/Header/components/hooks/useUserGreetingWalkthrough.tsx
+++ b/src/screens/HomeFlow/Home/components/Header/components/hooks/useUserGreetingWalkthrough.tsx
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
-import {SCREEN_SIDE_OFFSET} from '@constants/styles';
+import {SCREEN_SIDE_OFFSET, windowWidth} from '@constants/styles';
 import {UserGreeting} from '@screens/HomeFlow/Home/components/Header/components/UserGreeting';
 import {useSetWalkthroughElementData} from '@store/modules/Walkthrough/hooks/useSetWalkthroughElementData';
 import React, {useRef} from 'react';
 import {StyleSheet, View} from 'react-native';
-import {screenWidth} from 'rn-units';
 import {rem} from 'rn-units/index';
 
 const PADDING = rem(12);
@@ -49,13 +48,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     padding: PADDING,
-    width: screenWidth / 2,
+    width: windowWidth / 2,
   },
   container: {
     borderRadius: BORDER_RADIUS,
     backgroundColor: COLORS.white02opacity,
     padding: PADDING,
-    width: screenWidth / 2 + PADDING * 2,
+    width: windowWidth / 2 + PADDING * 2,
     marginLeft: SCREEN_SIDE_OFFSET - PADDING * 2,
   },
 });

--- a/src/screens/HomeFlow/Home/components/Overview/hooks/useInviteFriendsWalkthrough.tsx
+++ b/src/screens/HomeFlow/Home/components/Overview/hooks/useInviteFriendsWalkthrough.tsx
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {InviteButton} from '@components/InviteButton';
-import {SCREEN_SIDE_OFFSET} from '@constants/styles';
+import {SCREEN_SIDE_OFFSET, windowWidth} from '@constants/styles';
 import {WalkthroughElementContainer} from '@screens/Walkthrough/components/WalkthroughElementContainer';
 import {useSetWalkthroughElementData} from '@store/modules/Walkthrough/hooks/useSetWalkthroughElementData';
 import React, {useRef} from 'react';
 import {StyleSheet, View} from 'react-native';
-import {screenWidth} from 'rn-units';
 
 const CONTAINER_PADDING = SCREEN_SIDE_OFFSET / 2;
 
@@ -41,7 +40,7 @@ export const useInviteFriendsWalkthrough = () => {
 const styles = StyleSheet.create({
   inviteButtonStyle: {
     marginHorizontal: 0,
-    width: screenWidth - SCREEN_SIDE_OFFSET * 2,
+    width: windowWidth - SCREEN_SIDE_OFFSET * 2,
   },
   outerContainer: {
     alignSelf: 'center',

--- a/src/screens/HomeFlow/Home/components/Overview/index.tsx
+++ b/src/screens/HomeFlow/Home/components/Overview/index.tsx
@@ -4,7 +4,7 @@ import {FlipCard, FlipCardMethods} from '@components/FlipCard';
 import {InviteButton} from '@components/InviteButton';
 import {SectionHeader} from '@components/SectionHeader';
 import {COLORS} from '@constants/colors';
-import {SCREEN_SIDE_OFFSET} from '@constants/styles';
+import {SCREEN_SIDE_OFFSET, windowWidth} from '@constants/styles';
 import {useScrollShadow} from '@hooks/useScrollShadow';
 import {AdoptionCard} from '@screens/HomeFlow/Home/components/Overview/components/AdoptionCard';
 import {
@@ -35,7 +35,7 @@ import {
   View,
 } from 'react-native';
 import Animated, {SharedValue} from 'react-native-reanimated';
-import {isAndroid, isIOS, rem, screenWidth} from 'rn-units';
+import {isAndroid, isIOS, rem} from 'rn-units';
 
 const HEADER_RECTANGLE = require('../../assets/images/topRectangle.png');
 
@@ -160,8 +160,8 @@ const contentInset = {left: -OVERSCROLL, top: 0, bottom: 0, right: -OVERSCROLL};
 
 export const styles = StyleSheet.create({
   headerTopImage: {
-    width: screenWidth,
-    height: screenWidth * 0.08,
+    width: windowWidth,
+    height: windowWidth * 0.08,
     backgroundColor: COLORS.primaryLight,
   },
   sectionHeader: {

--- a/src/screens/HomeFlow/Stats/components/UsersGrowthGraph/components/PeriodSelect/index.tsx
+++ b/src/screens/HomeFlow/Stats/components/UsersGrowthGraph/components/PeriodSelect/index.tsx
@@ -2,7 +2,7 @@
 
 import {Touchable} from '@components/Touchable';
 import {COLORS} from '@constants/colors';
-import {SMALL_BUTTON_HIT_SLOP} from '@constants/styles';
+import {SMALL_BUTTON_HIT_SLOP, windowWidth} from '@constants/styles';
 import {MainStackParamList} from '@navigation/Main';
 import {useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
@@ -10,7 +10,7 @@ import {ChevronSmallIcon} from '@svg/ChevronSmallIcon';
 import {font} from '@utils/styles';
 import React, {useRef, useState} from 'react';
 import {StyleSheet, Text, TouchableOpacity} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 type Props = {
   selectedIndex: number;
@@ -30,7 +30,7 @@ export const PeriodSelect = ({selectedIndex, options, onChange}: Props) => {
       navigation.navigate('ContextualMenu', {
         coords: {
           top: y + height + rem(16),
-          right: screenWidth - x - rem(46),
+          right: windowWidth - x - rem(46),
         },
         buttons: options.map((option, index) => ({
           label: option.label,

--- a/src/screens/ImageView/index.tsx
+++ b/src/screens/ImageView/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {Header, HEADER_HEIGHT} from '@navigation/components/Header';
 import {MainStackParamList} from '@navigation/Main';
 import {RouteProp, useRoute} from '@react-navigation/native';
@@ -17,7 +18,6 @@ import {
   useSafeAreaFrame,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
-import {screenWidth} from 'rn-units';
 
 export const ImageView = () => {
   const {
@@ -25,7 +25,7 @@ export const ImageView = () => {
   } = useRoute<RouteProp<MainStackParamList, 'ImageView'>>();
 
   const {top: topInset, bottom: bottomInset} = useSafeAreaInsets();
-  const viewPortWidth = screenWidth;
+  const viewPortWidth = windowWidth;
   const frame = useSafeAreaFrame();
   const viewPortHeight = frame.height - topInset - bottomInset - HEADER_HEIGHT;
 

--- a/src/screens/InviteFlow/InviteFriend/index.tsx
+++ b/src/screens/InviteFlow/InviteFriend/index.tsx
@@ -4,7 +4,7 @@ import {IceLabel} from '@components/Labels/IceLabel';
 import {LinesBackground} from '@components/LinesBackground';
 import {PrimaryButton} from '@components/PrimaryButton';
 import {COLORS} from '@constants/colors';
-import {commonStyles, smallHeightDevice} from '@constants/styles';
+import {commonStyles, smallHeightDevice, windowWidth} from '@constants/styles';
 import {useScrollShadow} from '@hooks/useScrollShadow';
 import {Header} from '@navigation/components/Header';
 import {useFocusStatusBar} from '@navigation/hooks/useFocusStatusBar';
@@ -26,7 +26,7 @@ import React from 'react';
 import {Image, StyleSheet, Text, View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useDispatch} from 'react-redux';
-import {isAndroid, rem, screenWidth} from 'rn-units';
+import {isAndroid, rem} from 'rn-units';
 
 const icon = require('./assets/images/inviteFromAgendaGrafik.png');
 export const INVITE_CARD_TOP_OFFSET = rem(63);
@@ -153,13 +153,13 @@ const styles = StyleSheet.create({
     paddingTop: smallHeightDevice ? rem(6) : rem(24),
   },
   button: {
-    width: screenWidth,
+    width: windowWidth,
     alignItems: 'center',
     justifyContent: 'center',
     paddingTop: smallHeightDevice ? rem(20) : rem(24),
   },
   inviteButton: {
-    width: screenWidth - rem(100),
+    width: windowWidth - rem(100),
     backgroundColor: COLORS.primaryLight,
     height: rem(56),
     borderRadius: rem(16),

--- a/src/screens/InviteFlow/InviteShare/components/ShareButton/index.tsx
+++ b/src/screens/InviteFlow/InviteShare/components/ShareButton/index.tsx
@@ -6,10 +6,7 @@ import {font} from '@utils/styles';
 import React from 'react';
 import {Image, StyleSheet, Text} from 'react-native';
 import {Social} from 'react-native-share';
-import {rem, screenWidth} from 'rn-units';
-
-const BUTTON_LEFT_OFFSET = 32;
-const BUTTON_SIDE_DIMENSION = (screenWidth - BUTTON_LEFT_OFFSET * 5) / 4;
+import {rem} from 'rn-units';
 
 export type SocialShareButtonType = {
   type: SocialType;
@@ -37,17 +34,17 @@ export const ShareButton = ({button, onPress}: ShareButtonProps) => {
 
 const styles = StyleSheet.create({
   button: {
-    width: BUTTON_SIDE_DIMENSION,
-    marginLeft: BUTTON_LEFT_OFFSET,
+    width: '25%',
+    alignItems: 'center',
+    justifyContent: 'center',
     marginTop: rem(35),
   },
   icon: {
-    width: BUTTON_SIDE_DIMENSION,
-    height: BUTTON_SIDE_DIMENSION,
+    width: rem(56),
+    height: rem(56),
   },
   buttonTitle: {
     marginTop: rem(8),
-    alignSelf: 'center',
-    ...font(11, null, 'regular', 'secondary'),
+    ...font(11, 18, 'regular', 'secondary'),
   },
 });

--- a/src/screens/InviteFlow/InviteShare/components/ShareCard/index.tsx
+++ b/src/screens/InviteFlow/InviteShare/components/ShareCard/index.tsx
@@ -29,7 +29,7 @@ import {openComposer} from 'react-native-email-link';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Share, {ShareSingleOptions, Social} from 'react-native-share';
 import {useSelector} from 'react-redux';
-import {isIOS, rem} from 'rn-units';
+import {isAndroid, isIOS, rem} from 'rn-units';
 
 const telegramIcon = require('../../assets/images/telegramIcon.png');
 const twitterIcon = require('../../assets/images/twitterIcon.png');
@@ -157,8 +157,7 @@ const ShareCard = () => {
           break;
       }
     } catch (error) {
-      // Share.shareSingle throws this error on iOS if app is not installed and it opens AppStore
-      if (checkProp(error, 'code') && error.code === 'ECOM.RNSHARE1') {
+      if (isShareProviderNotInstalled(error)) {
         return;
       }
       logError(error);
@@ -186,6 +185,24 @@ const ShareCard = () => {
       </View>
     </View>
   );
+};
+
+const isShareProviderNotInstalled = (error: unknown) => {
+  if (
+    isAndroid &&
+    checkProp(error, 'error') &&
+    typeof error.error === 'string' &&
+    error.error.includes('No Activity found to handle Intent')
+  ) {
+    return true;
+  } else if (
+    isIOS &&
+    checkProp(error, 'code') &&
+    error.code === 'ECOM.RNSHARE1'
+  ) {
+    return true;
+  }
+  return false;
 };
 
 const styles = StyleSheet.create({

--- a/src/screens/InviteFlow/InviteShare/components/ShareCard/index.tsx
+++ b/src/screens/InviteFlow/InviteShare/components/ShareCard/index.tsx
@@ -29,7 +29,7 @@ import {openComposer} from 'react-native-email-link';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import Share, {ShareSingleOptions, Social} from 'react-native-share';
 import {useSelector} from 'react-redux';
-import {isIOS, rem, screenWidth} from 'rn-units';
+import {isIOS, rem} from 'rn-units';
 
 const telegramIcon = require('../../assets/images/telegramIcon.png');
 const twitterIcon = require('../../assets/images/twitterIcon.png');
@@ -191,20 +191,20 @@ const ShareCard = () => {
 const styles = StyleSheet.create({
   fullCard: {
     position: 'absolute',
-    backgroundColor: 'transparent',
     left: 0,
     bottom: 0,
-    width: screenWidth,
+    right: 0,
   },
   shareCard: {
-    width: screenWidth,
     position: 'absolute',
     left: 0,
     bottom: 0,
+    right: 0,
   },
   buttonsContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
+    marginHorizontal: rem(12),
   },
 });
 

--- a/src/screens/InviteFlow/InviteShare/index.tsx
+++ b/src/screens/InviteFlow/InviteShare/index.tsx
@@ -1,62 +1,46 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {IceLabel} from '@components/Labels/IceLabel';
+import {LinesBackground} from '@components/LinesBackground';
 import {COLORS} from '@constants/colors';
-import {Images} from '@images';
-import {Header, HEADER_HEIGHT} from '@navigation/components/Header';
+import {commonStyles, windowWidth} from '@constants/styles';
+import {Header} from '@navigation/components/Header';
 import {useFocusStatusBar} from '@navigation/hooks/useFocusStatusBar';
-import {useTopOffsetStyle} from '@navigation/hooks/useTopOffsetStyle';
 import ShareCard from '@screens/InviteFlow/InviteShare/components/ShareCard';
 import {t} from '@translations/i18n';
 import {font} from '@utils/styles';
 import React, {memo} from 'react';
 import {Image, StyleSheet, Text, View} from 'react-native';
-import {isAndroid, rem, screenHeight, screenWidth} from 'rn-units';
+import {isAndroid, rem, screenHeight} from 'rn-units';
 
 const icon = require('./assets/images/share.png');
 
 const ICON_LEFT_OFFSET = rem(21);
-const ICON_WIDTH = screenWidth - ICON_LEFT_OFFSET;
+const ICON_WIDTH = windowWidth - ICON_LEFT_OFFSET;
 
 export const InviteShare = memo(() => {
   useFocusStatusBar({style: 'dark-content'});
 
-  const {
-    current: {paddingTop},
-  } = useTopOffsetStyle();
-
-  const top = HEADER_HEIGHT + paddingTop + rem(12);
-
   return (
-    <View style={styles.container}>
+    <View style={commonStyles.flexOne}>
       <Header color={COLORS.primaryDark} title={t('invite_share.title')} />
-      <View style={styles.shareSubstrate} />
-      <Image
-        style={[styles.bg, {top}]}
-        source={Images.backgrounds.linesBg}
-        resizeMode="stretch"
-      />
-      <Text style={styles.description}>
-        {t('invite_share.description_part1')}
-        <IceLabel iconOffsetY={isAndroid ? 3 : 2} />
-        {t('invite_share.description_part2')}
-      </Text>
-      <Image source={icon} style={styles.icon} />
-      <ShareCard />
+      <View style={commonStyles.flexOne}>
+        <View style={styles.shareSubstrate} />
+        <LinesBackground style={styles.bg} />
+        <Text style={styles.description}>
+          {t('invite_share.description_part1')}
+          <IceLabel iconOffsetY={isAndroid ? 3 : 2} />
+          {t('invite_share.description_part2')}
+        </Text>
+        <Image source={icon} style={styles.icon} />
+        <ShareCard />
+      </View>
     </View>
   );
 });
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: COLORS.white,
-  },
   bg: {
-    position: 'absolute',
-    left: 0,
-    height: screenWidth * 1.266,
-    width: screenWidth,
     borderTopLeftRadius: rem(30),
     borderTopRightRadius: rem(30),
   },
@@ -76,7 +60,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 0,
     left: 0,
-    width: screenWidth,
+    right: 0,
     height: screenHeight / 2,
     backgroundColor: COLORS.primaryLight,
   },

--- a/src/screens/Modals/PopUp/components/Checkbox/index.tsx
+++ b/src/screens/Modals/PopUp/components/Checkbox/index.tsx
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import {windowWidth} from '@constants/styles';
 import {SquareCheckboxActiveIcon} from '@svg/SquareCheckboxActiveIcon';
 import {SquareCheckboxInactiveIcon} from '@svg/SquareCheckboxInactiveIcon';
 import {font} from '@utils/styles';
 import React from 'react';
 import {StyleSheet, Text, TouchableWithoutFeedback, View} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 type Props = {
   text: string;
@@ -37,7 +38,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     marginTop: rem(15),
     alignSelf: 'center',
-    width: screenWidth * 0.78,
+    width: windowWidth * 0.78,
     minHeight: rem(30),
   },
   checkBoxContainer: {

--- a/src/screens/Modals/ProfilePrivacyEdit/step1/index.tsx
+++ b/src/screens/Modals/ProfilePrivacyEdit/step1/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {Images} from '@images';
 import {MainNavigationParams} from '@navigation/Main';
 import {useNavigation} from '@react-navigation/native';
@@ -14,7 +15,7 @@ import {t} from '@translations/i18n';
 import React from 'react';
 import {ImageBackground, StyleSheet, View} from 'react-native';
 import {useSelector} from 'react-redux';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export const ProfilePrivacyEditStep1 = () => {
   const navigation =
@@ -52,7 +53,7 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.transparentBackground,
   },
   container: {
-    width: screenWidth,
+    width: windowWidth,
     height: rem(418),
     paddingBottom: rem(40),
   },

--- a/src/screens/Modals/ProfilePrivacyEdit/step2/index.tsx
+++ b/src/screens/Modals/ProfilePrivacyEdit/step2/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {Images} from '@images';
 import {MainNavigationParams} from '@navigation/Main';
 import {useNavigation} from '@react-navigation/native';
@@ -15,7 +16,7 @@ import {t} from '@translations/i18n';
 import React from 'react';
 import {ImageBackground, StyleSheet, View} from 'react-native';
 import {useSelector} from 'react-redux';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export const ProfilePrivacyEditStep2 = () => {
   const navigation =
@@ -64,7 +65,7 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.transparentBackground,
   },
   container: {
-    width: screenWidth,
+    width: windowWidth,
     height: rem(461),
     paddingBottom: rem(40),
     marginTop: rem(100),

--- a/src/screens/Modals/ProfilePrivacyEdit/step3/index.tsx
+++ b/src/screens/Modals/ProfilePrivacyEdit/step3/index.tsx
@@ -2,6 +2,7 @@
 
 import {User} from '@api/user/types';
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {Images} from '@images';
 import {useNavigation} from '@react-navigation/native';
 import {CancelButton} from '@screens/Modals/ProfilePrivacyEdit/components/CancelButton';
@@ -14,7 +15,7 @@ import {t} from '@translations/i18n';
 import React from 'react';
 import {ImageBackground, StyleSheet, View} from 'react-native';
 import {useSelector} from 'react-redux';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export const ProfilePrivacyEditStep3 = () => {
   const navigation = useNavigation();
@@ -59,7 +60,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   container: {
-    width: screenWidth,
+    width: windowWidth,
     height: rem(565),
   },
   badgesContainer: {

--- a/src/screens/Notifications/components/NotificationsList/index.tsx
+++ b/src/screens/Notifications/components/NotificationsList/index.tsx
@@ -3,7 +3,7 @@
 import {Activity, ActivitySection} from '@api/notifications/types';
 import {Touchable} from '@components/Touchable';
 import {COLORS} from '@constants/colors';
-import {commonStyles} from '@constants/styles';
+import {commonStyles, windowWidth} from '@constants/styles';
 import {useScrollShadow} from '@hooks/useScrollShadow';
 import {Header} from '@navigation/components/Header';
 import {ClearButton} from '@navigation/components/Header/components/ClearButton';
@@ -26,7 +26,7 @@ import {
 import Swipeable from 'react-native-gesture-handler/Swipeable';
 import LinearGradient from 'react-native-linear-gradient';
 import {useDispatch} from 'react-redux';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 export interface ActivityItemProps {
   activity: Activity;
@@ -176,7 +176,7 @@ export const NotificationsList = ({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    width: screenWidth,
+    width: windowWidth,
     marginTop: rem(15),
   },
   itemContainer: {
@@ -200,13 +200,13 @@ const styles = StyleSheet.create({
     paddingLeft: rem(15),
   },
   sectionTitle: {
-    width: screenWidth,
+    width: windowWidth,
     ...font(12, 14, 'regular', 'secondary'),
     textAlign: 'center',
     marginVertical: rem(9),
   },
   bottomGradient: {
-    width: screenWidth,
+    width: windowWidth,
     height: rem(85),
     position: 'absolute',
     bottom: 0,

--- a/src/screens/ProfileFlow/Profile/components/AgendaContactTooltip/index.tsx
+++ b/src/screens/ProfileFlow/Profile/components/AgendaContactTooltip/index.tsx
@@ -3,13 +3,14 @@
 import {ContactAvatar} from '@components/ContactAvatar';
 import {Tooltip} from '@components/Tooltip';
 import {COLORS} from '@constants/colors';
+import {windowWidth} from '@constants/styles';
 import {AVATAR_SIZE} from '@screens/ProfileFlow/Profile/components/AvatarHeader';
 import {font} from '@utils/styles';
 import React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 import {Contact} from 'react-native-contacts';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 const MIN_TOOLTIP_WIDTH = rem(220);
 const CHEVRON_LEFT_OFFSET = MIN_TOOLTIP_WIDTH / 2 + AVATAR_SIZE / 2 - rem(23);
@@ -54,7 +55,7 @@ export const AgendaContactTooltip = ({contact}: AgendaContactTooltipProps) => {
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    maxWidth: screenWidth - rem(100),
+    maxWidth: windowWidth - rem(100),
     minWidth: MIN_TOOLTIP_WIDTH,
     alignSelf: 'center',
     flexDirection: 'row',

--- a/src/screens/ProfileFlow/Profile/components/AvatarHeader/hooks/useAnimatedStyles.ts
+++ b/src/screens/ProfileFlow/Profile/components/AvatarHeader/hooks/useAnimatedStyles.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import {COLORS} from '@constants/colors';
 import {HEADER_HEIGHT} from '@navigation/components/Header';
 import {AVATAR_SIZE} from '@screens/ProfileFlow/Profile/components/AvatarHeader';
 import {ViewStyle} from 'react-native';
@@ -8,10 +7,8 @@ import {
   AnimatedStyleProp,
   Extrapolate,
   interpolate,
-  interpolateColor,
   SharedValue,
   useAnimatedStyle,
-  useDerivedValue,
 } from 'react-native-reanimated';
 import {rem} from 'rn-units';
 
@@ -27,114 +24,114 @@ type Params = {
 };
 
 export const useAnimatedStyles = ({scrollY}: Params) => {
-  const imageSize = useDerivedValue(() =>
-    interpolate(
+  const imageAnimatedStyle = useAnimatedStyle(() => {
+    const size = interpolate(
       scrollY.value,
       [0, MAX_SCROLL],
       [AVATAR_SIZE, AVATAR_SMALL_SIZE],
       Extrapolate.CLAMP,
-    ),
-  );
+    );
 
-  const penSize = useDerivedValue(() =>
-    interpolate(
-      scrollY.value,
-      [0, MAX_SCROLL / 2],
-      [PEN_SIZE, 0],
-      Extrapolate.CLAMP,
-    ),
-  );
-
-  const marginTop = useDerivedValue(() =>
-    interpolate(
+    const borderWidth = interpolate(
       scrollY.value,
       [0, MAX_SCROLL],
-      [AVATAR_SIZE / 2 + HEADER_HEIGHT / 2 + 8, 0],
+      [5, 0],
       Extrapolate.CLAMP,
-    ),
-  );
+    );
 
-  const borderWidth = useDerivedValue(() =>
-    interpolate(scrollY.value, [0, MAX_SCROLL], [5, 0], Extrapolate.CLAMP),
-  );
-
-  const borderRadius = useDerivedValue(() =>
-    interpolate(
+    const borderRadius = interpolate(
       scrollY.value,
       [0, MAX_SCROLL],
       [AVATAR_RADIUS, AVATAR_SMALL_RADIUS],
       Extrapolate.CLAMP,
-    ),
-  );
+    );
 
-  const imageAnimatedStyle = useAnimatedStyle(() => {
-    return {
-      height: imageSize.value,
-      width: imageSize.value,
-      borderWidth: borderWidth.value,
-      borderRadius: borderRadius.value,
-      marginTop: marginTop.value,
-    };
+    const marginTop = interpolate(
+      scrollY.value,
+      [0, MAX_SCROLL],
+      [AVATAR_SIZE / 2 + HEADER_HEIGHT / 2 + 8, 0],
+      Extrapolate.CLAMP,
+    );
+
+    return {height: size, width: size, borderWidth, borderRadius, marginTop};
   });
-
-  const penOpacity = useDerivedValue(() =>
-    interpolate(scrollY.value, [0, MAX_SCROLL / 2], [1, 0], Extrapolate.CLAMP),
-  );
 
   const penAnimatedStyle = useAnimatedStyle(() => {
+    const size = interpolate(
+      scrollY.value,
+      [0, MAX_SCROLL / 2],
+      [PEN_SIZE, 0],
+      Extrapolate.CLAMP,
+    );
+
+    const opacity = interpolate(
+      scrollY.value,
+      [0, MAX_SCROLL / 2],
+      [1, 0],
+      Extrapolate.CLAMP,
+    );
+
     return {
-      height: penSize.value,
-      width: penSize.value,
-      opacity: penOpacity.value,
+      height: size,
+      width: size,
+      opacity,
     };
   });
 
-  const textOpacity = useDerivedValue(() =>
-    interpolate(scrollY.value, [130, SCROLL_STEP_1], [0, 1], Extrapolate.CLAMP),
-  );
+  const textStyle = useAnimatedStyle(() => {
+    const opacity = interpolate(
+      scrollY.value,
+      [130, SCROLL_STEP_1],
+      [0, 1],
+      Extrapolate.CLAMP,
+    );
 
-  const lettersAvatarOpacity = useDerivedValue(() =>
-    interpolate(scrollY.value, [0, 5], [1, 0], Extrapolate.CLAMP),
-  );
-
-  const fontSize = useDerivedValue(() =>
-    interpolate(
+    const fontSize = interpolate(
       scrollY.value,
       [0, SCROLL_STEP_1],
       [0.01, 17],
       Extrapolate.CLAMP,
-    ),
-  );
+    );
 
-  const marginLeft = useDerivedValue(() =>
-    interpolate(scrollY.value, [0, MAX_SCROLL], [0, 12], Extrapolate.CLAMP),
-  );
-
-  const textStyle = useAnimatedStyle(() => ({
-    opacity: textOpacity.value,
-    fontSize: fontSize.value,
-    marginLeft: marginLeft.value,
-  }));
-
-  const lettersAvatarStyle: AnimatedStyleProp<ViewStyle> = useAnimatedStyle(
-    () => ({
-      opacity: lettersAvatarOpacity.value,
-    }),
-  );
-
-  const iconAnimatedColor = useDerivedValue(() =>
-    interpolateColor(
+    const marginLeft = interpolate(
       scrollY.value,
       [0, MAX_SCROLL],
-      [COLORS.primaryDark, COLORS.alabaster],
-    ),
+      [0, 12],
+      Extrapolate.CLAMP,
+    );
+
+    return {opacity, fontSize, marginLeft};
+  });
+
+  const lettersAvatarStyle: AnimatedStyleProp<ViewStyle> = useAnimatedStyle(
+    () => {
+      const opacity = interpolate(
+        scrollY.value,
+        [0, 5],
+        [1, 0],
+        Extrapolate.CLAMP,
+      );
+
+      return {opacity};
+    },
   );
+
+  const iconAvatarStyle: AnimatedStyleProp<ViewStyle> = useAnimatedStyle(() => {
+    const opacity = interpolate(
+      scrollY.value,
+      [0, MAX_SCROLL],
+      [1, 0],
+      Extrapolate.CLAMP,
+    );
+
+    return {opacity};
+  });
 
   return {
     imageAnimatedStyle,
     penAnimatedStyle,
     textStyle,
     lettersAvatarStyle,
-    iconAnimatedColor,
+    iconAvatarStyle,
   };
 };

--- a/src/screens/ProfileFlow/Profile/components/AvatarHeader/index.tsx
+++ b/src/screens/ProfileFlow/Profile/components/AvatarHeader/index.tsx
@@ -6,7 +6,11 @@ import {Avatar, AvatarSkeleton} from '@components/Avatar/Avatar';
 import {ContactAvatar} from '@components/ContactAvatar';
 import {Touchable} from '@components/Touchable';
 import {COLORS} from '@constants/colors';
-import {commonStyles, MIDDLE_BUTTON_HIT_SLOP} from '@constants/styles';
+import {
+  commonStyles,
+  MIDDLE_BUTTON_HIT_SLOP,
+  windowWidth,
+} from '@constants/styles';
 import {useActionSheetUpdateAvatar} from '@hooks/useActionSheetUpdateAvatar';
 import {useScrollShadow} from '@hooks/useScrollShadow';
 import {useUpdateAvatar} from '@hooks/useUpdateAvatar';
@@ -26,7 +30,7 @@ import {Image, StyleSheet, View} from 'react-native';
 import {Contact} from 'react-native-contacts';
 import Animated, {SharedValue} from 'react-native-reanimated';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 const AnimatedTouchable = Animated.createAnimatedComponent(Touchable);
 
@@ -174,7 +178,7 @@ const styles = StyleSheet.create({
     height: HEADER_HEIGHT,
     justifyContent: 'center',
     flexDirection: 'row',
-    width: screenWidth,
+    width: windowWidth,
     overflow: 'visible',
     backgroundColor: COLORS.white,
     zIndex: 1000,

--- a/src/screens/ProfileFlow/Profile/components/AvatarHeader/index.tsx
+++ b/src/screens/ProfileFlow/Profile/components/AvatarHeader/index.tsx
@@ -65,7 +65,7 @@ export const AvatarHeader = memo(
       penAnimatedStyle,
       textStyle,
       lettersAvatarStyle,
-      iconAnimatedColor,
+      iconAvatarStyle,
     } = useAnimatedStyles({scrollY});
 
     const extraPadding = {
@@ -127,7 +127,7 @@ export const AvatarHeader = memo(
                 {updateAvatarLoading ? (
                   <ActivityIndicator style={StyleSheet.absoluteFill} />
                 ) : (
-                  <AnimatedCameraIcon animatedColor={iconAnimatedColor} />
+                  <AnimatedCameraIcon style={iconAvatarStyle} />
                 )}
               </AnimatedTouchable>
             )}

--- a/src/screens/Templates/FinalizeRegistrationStep/components/Background/index.tsx
+++ b/src/screens/Templates/FinalizeRegistrationStep/components/Background/index.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import {windowWidth} from '@constants/styles';
 import React from 'react';
 import {Image, StyleSheet} from 'react-native';
-import {screenWidth} from 'rn-units';
 
 export const Background = () => {
   return (
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     left: 0,
-    width: screenWidth,
-    height: (screenWidth / 375) * 650,
+    width: windowWidth,
+    height: (windowWidth / 375) * 650,
   },
 });

--- a/src/screens/Templates/FinalizeRegistrationStep/index.tsx
+++ b/src/screens/Templates/FinalizeRegistrationStep/index.tsx
@@ -3,7 +3,7 @@
 import {BackButton} from '@components/BackButton';
 import {KeyboardAvoider} from '@components/KeyboardAvoider';
 import {COLORS} from '@constants/colors';
-import {smallHeightDevice} from '@constants/styles';
+import {smallHeightDevice, windowWidth} from '@constants/styles';
 import {useScrollEndOnKeyboardShown} from '@hooks/useScrollEndOnKeyboardShown';
 import {useScrollOpacity} from '@hooks/useScrollOpacity';
 import {Header} from '@navigation/components/Header';
@@ -13,7 +13,7 @@ import React, {ReactNode} from 'react';
 import {Image, ImageSourcePropType, StyleSheet, View} from 'react-native';
 import Animated from 'react-native-reanimated';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 type Props = {
   title: string;
@@ -96,8 +96,8 @@ const styles = StyleSheet.create({
     zIndex: 1,
   },
   illustration: {
-    width: screenWidth,
-    height: (screenWidth * 250) / 375,
+    width: windowWidth,
+    height: (windowWidth * 250) / 375,
   },
   controls: {
     backgroundColor: COLORS.white,

--- a/src/screens/Walkthrough/components/StepCircle/index.tsx
+++ b/src/screens/Walkthrough/components/StepCircle/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {Touchable} from '@components/Touchable';
-import {MIDDLE_BUTTON_HIT_SLOP} from '@constants/styles';
+import {MIDDLE_BUTTON_HIT_SLOP, windowWidth} from '@constants/styles';
 import {Images} from '@images';
 import {NextButton} from '@screens/Walkthrough/components/StepCircle/components/NextButton';
 import {useCirclePosition} from '@screens/Walkthrough/components/StepCircle/hooks/useCirclePosition';
@@ -13,7 +13,7 @@ import {font} from '@utils/styles';
 import React from 'react';
 import {Image, StyleSheet, Text, View, ViewStyle} from 'react-native';
 import Animated, {AnimatedStyleProp} from 'react-native-reanimated';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 type Props = {
   step: WalkthroughStep;
@@ -78,7 +78,7 @@ const styles = StyleSheet.create({
   circleContainer: {
     position: 'absolute',
     justifyContent: 'center',
-    width: screenWidth,
+    width: windowWidth,
     height: CIRCLE_DIAMETER,
     paddingHorizontal: rem(30),
   },

--- a/src/screens/Walkthrough/constants.ts
+++ b/src/screens/Walkthrough/constants.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import {smallHeightDevice} from '@constants/styles';
-import {rem, screenWidth} from 'rn-units/index';
+import {smallHeightDevice, windowWidth} from '@constants/styles';
+import {rem} from 'rn-units/index';
 
-export const CIRCLE_DIAMETER = screenWidth * (smallHeightDevice ? 1 : 1.1);
+export const CIRCLE_DIAMETER = windowWidth * (smallHeightDevice ? 1 : 1.1);
 
 export const CIRCLE_TO_ELEMENT_OFFSET = rem(10);
 

--- a/src/screens/WelcomeFlow/Onboarding/components/Background/index.tsx
+++ b/src/screens/WelcomeFlow/Onboarding/components/Background/index.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import {windowWidth} from '@constants/styles';
 import React from 'react';
 import {Image, StyleSheet} from 'react-native';
-import {screenWidth} from 'rn-units';
 
 export const Background = () => {
   return (
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     left: 0,
-    width: screenWidth,
-    height: (screenWidth / 375) * 650,
+    width: windowWidth,
+    height: (windowWidth / 375) * 650,
   },
 });

--- a/src/screens/WelcomeFlow/Onboarding/components/OnboardingSlide/index.tsx
+++ b/src/screens/WelcomeFlow/Onboarding/components/OnboardingSlide/index.tsx
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import {smallHeightDevice} from '@constants/styles';
+import {smallHeightDevice, windowWidth} from '@constants/styles';
 import {font} from '@utils/styles';
 import * as React from 'react';
 import {Image, ImageSourcePropType, StyleSheet, Text, View} from 'react-native';
-import {rem, screenWidth} from 'rn-units';
+import {rem} from 'rn-units';
 
 type Props = {
   title: string | React.ReactNode;
@@ -42,7 +42,7 @@ const styles = StyleSheet.create({
     ...font(14, 24, 'medium', 'white'),
   },
   image: {
-    width: screenWidth,
-    height: (screenWidth * 330) / 375,
+    width: windowWidth,
+    height: (windowWidth * 330) / 375,
   },
 });

--- a/src/services/firebase/index.tsx
+++ b/src/services/firebase/index.tsx
@@ -5,9 +5,12 @@ import messaging from '@react-native-firebase/messaging';
 import {logError} from '@services/logging';
 import {isIOS} from 'rn-units';
 
+export const isPlayServicesAvailable =
+  firebaseApp.utils().playServicesAvailability.isAvailable;
+
 export const getFcmToken = () => {
   try {
-    if (isIOS || firebaseApp.utils().playServicesAvailability.isAvailable) {
+    if (isIOS || isPlayServicesAvailable) {
       return messaging().getToken();
     }
     return '';

--- a/src/translations/locales/en.json
+++ b/src/translations/locales/en.json
@@ -191,7 +191,9 @@
     "requires_recent_login": "This operation is sensitive and requires recent authentication. Please sign in again",
     "same_email": "You can’t use the same e-mail",
     "weak_password": "Weak password",
-    "wrong_password": "Wrong password"
+    "wrong_password": "Wrong password",
+    "no_camera_permissions": "Camera permissions are not granted",
+    "no_library_permissions": "Library permissions are not granted"
   },
   "profile": {
     "my_roles": {

--- a/src/translations/locales/en.json.d.ts
+++ b/src/translations/locales/en.json.d.ts
@@ -141,6 +141,8 @@ export type Translations = {
   'errors.same_email': null;
   'errors.weak_password': null;
   'errors.wrong_password': null;
+  'errors.no_camera_permissions': null;
+  'errors.no_library_permissions': null;
   'profile.my_roles.title': null;
   'profile.mining_calculator': null;
   'profile.invite_friends': null;


### PR DESCRIPTION
* Fix profile avatar scroll animation of the camera icon
* Change `windowWidth` usage to `screenWidth` so it works as expected on android devices with side cutoffs
* Improve image picker flow. Call openPicker/openCamera and openCropper separately, so library converts selected image to jpg before cropping. This workaround saves from variety of errors on android (e.g. when picking webp)
* Handle image picker `E_NO_CAMERA_PERMISSION` / `E_NO_LIBRARY_PERMISSION` errors
* Hide Sign In With Google if play services are not available on device
* Omit share error if provider is not installed
* Adjust "invite friend" screen markdown and styles