### PR TITLE
enable phone number auth for non zh

### DIFF
--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -3,14 +3,21 @@
 import {deviceMainLocale} from '@translations/i18n';
 
 /**
- * Is Email Link sign-in flow used instead of Email + Password
+ * Is Email Link sign in flow used instead of Email + Password
  */
 export const isEmailLinkSignIn = deviceMainLocale.languageCode !== 'zh';
 
 /**
- * Is enabled:
- *  - Sign-in with phone number
- *  - Link phone number on the Team Screen
- *  - Change phone number on the Personal Information Screen
+ * Is sign in with phone number enabled
  */
-export const isPhoneNumberEnabled = false;
+export const isPhoneNumberAuthEnabled = deviceMainLocale.languageCode !== 'zh';
+
+/**
+ * Is linking phone number on the Team Screen enabled
+ */
+export const isLinkPhoneNumberEnabled = false;
+
+/**
+ * Is changing phone number on the Settings -> Personal Information Screen enabled
+ */
+export const isChangePhoneNumberEnabled = false;

--- a/src/screens/AuthFlow/SignIn/index.tsx
+++ b/src/screens/AuthFlow/SignIn/index.tsx
@@ -4,7 +4,10 @@ import {FullScreenLoading} from '@components/FullScreenLoading';
 import {KeyboardAvoider} from '@components/KeyboardAvoider';
 import {PrivacyTerms} from '@components/PrivacyTerms';
 import {COLORS} from '@constants/colors';
-import {isEmailLinkSignIn, isPhoneNumberEnabled} from '@constants/featureFlags';
+import {
+  isEmailLinkSignIn,
+  isPhoneNumberAuthEnabled,
+} from '@constants/featureFlags';
 import {useScrollEndOnKeyboardShown} from '@hooks/useScrollEndOnKeyboardShown';
 import {AuthStackParamList} from '@navigation/Auth';
 import {useFocusStatusBar} from '@navigation/hooks/useFocusStatusBar';
@@ -64,7 +67,7 @@ export const SignIn = () => {
             onSelect={setActiveTab}
             selected={activeTab}
             hiddenTab={
-              isResetPassword || !isPhoneNumberEnabled ? 'phone' : null
+              isResetPassword || !isPhoneNumberAuthEnabled ? 'phone' : null
             }
             containerStyle={styles.tabs}
           />

--- a/src/screens/SettingsFlow/PersonalInformation/index.tsx
+++ b/src/screens/SettingsFlow/PersonalInformation/index.tsx
@@ -6,7 +6,7 @@ import {KeyboardAvoider} from '@components/KeyboardAvoider';
 import {PrimaryButton} from '@components/PrimaryButton';
 import {UserAvatarHeader} from '@components/UserAvatarHeader';
 import {COLORS} from '@constants/colors';
-import {isPhoneNumberEnabled} from '@constants/featureFlags';
+import {isChangePhoneNumberEnabled} from '@constants/featureFlags';
 import {commonStyles} from '@constants/styles';
 import {Header} from '@navigation/components/Header';
 import {useBottomTabBarOffsetStyle} from '@navigation/hooks/useBottomTabBarOffsetStyle';
@@ -99,7 +99,7 @@ export const PersonalInformation = memo(() => {
             containerStyle={styles.input}
             icon={<PersonWithPenIcon width={rem(24)} height={rem(24)} />}
           />
-          {isPhoneNumberEnabled && (
+          {isChangePhoneNumberEnabled && (
             <CommonInput
               label={t('personal_information.phone')}
               editable={!isUpdateLoading}

--- a/src/screens/Team/components/Contacts/index.tsx
+++ b/src/screens/Team/components/Contacts/index.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
-import {isPhoneNumberEnabled} from '@constants/featureFlags';
+import {isLinkPhoneNumberEnabled} from '@constants/featureFlags';
 import {BottomSheetScrollView} from '@gorhom/bottom-sheet';
 import {ConfirmPhoneNumber} from '@screens/Team/components/Contacts/components/ConfirmPhoneNumber';
 import {ContactsList} from '@screens/Team/components/Contacts/components/ContactsList';
@@ -36,7 +36,7 @@ export const Contacts = ({
   const currentScreen = useMemo(() => {
     if (!hasContactsPermissions) {
       return 'ContactsPermissions';
-    } else if (isPhoneNumberEnabled && !isPhoneNumberVerified) {
+    } else if (isLinkPhoneNumberEnabled && !isPhoneNumberVerified) {
       if (temporaryPhoneVerificationStep === 'phone') {
         return 'ModifyPhoneNumber';
       } else {


### PR DESCRIPTION
Split `isPhoneNumberEnabled` feature flag to 3 separate ones - `isPhoneNumberAuthEnabled`, `isLinkPhoneNumberEnabled` and `isChangePhoneNumberEnabled`.
Enable `isPhoneNumberAuthEnabled` for non-zh users