### PR TITLE
chore: walkthrough fixes

### DIFF
--- a/src/navigation/Main.tsx
+++ b/src/navigation/Main.tsx
@@ -63,7 +63,7 @@ import {ActiveTabActions, Tab} from '@store/modules/ActiveTab/actions';
 import {useSubscribeToPushNotifications} from '@store/modules/PushNotifications/hooks/useSubscribeToPushNotifications';
 import {StatsPeriod} from '@store/modules/Stats/types';
 import {WalkthroughStep} from '@store/modules/Walkthrough/types';
-import React, {ComponentType, RefObject} from 'react';
+import React, {ComponentType, RefObject, useEffect} from 'react';
 import {Image, StyleSheet, View} from 'react-native';
 import {Contact} from 'react-native-contacts';
 import Animated from 'react-native-reanimated';
@@ -263,6 +263,10 @@ const MainTabs = () => {
         dispatch(ActiveTabActions.SET_ACTIVE_TAB.STATE.create(tab)),
     });
   };
+
+  useEffect(() => {
+    dispatch(ActiveTabActions.SET_ACTIVE_TAB.STATE.create('home'));
+  }, [dispatch]);
   return (
     <Tabs.Navigator screenOptions={tabOptions} tabBar={MainTabBarComponent}>
       <Tabs.Screen

--- a/src/navigation/Main.tsx
+++ b/src/navigation/Main.tsx
@@ -63,7 +63,7 @@ import {ActiveTabActions, Tab} from '@store/modules/ActiveTab/actions';
 import {useSubscribeToPushNotifications} from '@store/modules/PushNotifications/hooks/useSubscribeToPushNotifications';
 import {StatsPeriod} from '@store/modules/Stats/types';
 import {WalkthroughStep} from '@store/modules/Walkthrough/types';
-import React, {ComponentType, RefObject, useEffect} from 'react';
+import React, {ComponentType, RefObject} from 'react';
 import {Image, StyleSheet, View} from 'react-native';
 import {Contact} from 'react-native-contacts';
 import Animated from 'react-native-reanimated';
@@ -264,9 +264,6 @@ const MainTabs = () => {
     });
   };
 
-  useEffect(() => {
-    dispatch(ActiveTabActions.SET_ACTIVE_TAB.STATE.create('home'));
-  }, [dispatch]);
   return (
     <Tabs.Navigator screenOptions={tabOptions} tabBar={MainTabBarComponent}>
       <Tabs.Screen

--- a/src/store/modules/ActiveTab/reducer/index.ts
+++ b/src/store/modules/ActiveTab/reducer/index.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ice License 1.0
 
+import {AccountActions} from '@store/modules/Account/actions';
 import {ActiveTabActions, Tab} from '@store/modules/ActiveTab/actions';
 import produce from 'immer';
 
@@ -7,7 +8,9 @@ export interface State {
   activeTab: Tab;
 }
 
-type Actions = ReturnType<typeof ActiveTabActions.SET_ACTIVE_TAB.STATE.create>;
+type Actions =
+  | ReturnType<typeof ActiveTabActions.SET_ACTIVE_TAB.STATE.create>
+  | ReturnType<typeof AccountActions.SIGN_OUT.SUCCESS.create>;
 
 const INITIAL_STATE: State = {
   activeTab: 'home',
@@ -19,6 +22,11 @@ export function activeTab(state = INITIAL_STATE, action: Actions): State {
       case ActiveTabActions.SET_ACTIVE_TAB.STATE.type:
         draft.activeTab = action.payload.tab;
         break;
+      case AccountActions.SIGN_OUT.SUCCESS.type: {
+        return {
+          ...INITIAL_STATE,
+        };
+      }
     }
   });
 }

--- a/src/store/modules/Walkthrough/sagas/showWalkthroughSaga.tsx
+++ b/src/store/modules/Walkthrough/sagas/showWalkthroughSaga.tsx
@@ -11,6 +11,9 @@ import {AccountActions} from '@store/modules/Account/actions';
 import {userSelector} from '@store/modules/Account/selectors';
 import {WalkthroughActions} from '@store/modules/Walkthrough/actions';
 import {walkthroughStepCandidatesSelector} from '@store/modules/Walkthrough/selectors';
+import {HOME_WALKTHROUGH_STEPS} from '@store/modules/Walkthrough/steps/home';
+import {NEWS_WALKTHROUGH_STEPS} from '@store/modules/Walkthrough/steps/news';
+import {TEAM_WALKTHROUGH_STEPS} from '@store/modules/Walkthrough/steps/team';
 import {
   WalkthroughStep,
   WalkthroughStepKey,
@@ -24,6 +27,18 @@ import {
   select,
   take,
 } from 'redux-saga/effects';
+
+export function getAllSteps({step}: {step: WalkthroughStep}) {
+  if (HOME_WALKTHROUGH_STEPS.some(homeStep => homeStep.key === step.key)) {
+    return HOME_WALKTHROUGH_STEPS;
+  }
+  if (TEAM_WALKTHROUGH_STEPS.some(teamStep => teamStep.key === step.key)) {
+    return TEAM_WALKTHROUGH_STEPS;
+  }
+  if (NEWS_WALKTHROUGH_STEPS.some(newsStep => newsStep.key === step.key)) {
+    return NEWS_WALKTHROUGH_STEPS;
+  }
+}
 
 export function* showWalkthroughSaga() {
   while (true) {
@@ -86,7 +101,11 @@ export function* showWalkthroughSaga() {
         yield call(closeWalkthrough);
 
         if (action.type === WalkthroughActions.SKIP_WALKTHROUGH.STATE.type) {
-          yield call(markAllWalkthroughSteps, user, steps);
+          yield call(
+            markAllWalkthroughSteps,
+            user,
+            getAllSteps({step}) ?? steps,
+          );
         }
 
         break;

--- a/src/store/modules/Walkthrough/selectors/index.ts
+++ b/src/store/modules/Walkthrough/selectors/index.ts
@@ -62,6 +62,7 @@ export const walkthroughStepCandidatesSelector = createSelector(
     if (!user) {
       return [];
     }
+
     return getStepsByActiveTabAndScreenName({
       activeTab,
     }).reduce<WalkthroughStep[]>((result, step) => {

--- a/src/store/modules/Walkthrough/selectors/index.ts
+++ b/src/store/modules/Walkthrough/selectors/index.ts
@@ -62,7 +62,6 @@ export const walkthroughStepCandidatesSelector = createSelector(
     if (!user) {
       return [];
     }
-
     return getStepsByActiveTabAndScreenName({
       activeTab,
     }).reduce<WalkthroughStep[]>((result, step) => {


### PR DESCRIPTION
Fixed an issue when after log out and log back in with a new account the home walkthrough wasn't triggered.
Fixed an issue when `Skip All` action skipped only all currently available walkthroughs for the specific tab. Now it should skip all tab walkthroughs