### PR TITLE
process empty password error

### DIFF
--- a/src/store/modules/Account/sagas/signInEmailPassword.ts
+++ b/src/store/modules/Account/sagas/signInEmailPassword.ts
@@ -9,6 +9,7 @@ import {call, put} from 'redux-saga/effects';
 
 enum ValidateError {
   InvalidEmail,
+  InvalidPassword,
 }
 
 export function* signInEmailPasswordSaga(
@@ -23,17 +24,33 @@ export function* signInEmailPasswordSaga(
       throw {code: ValidateError.InvalidEmail};
     }
 
+    if (!password) {
+      throw {code: ValidateError.InvalidPassword};
+    }
+
     yield call(signInWithEmailAndPassword, email, password);
 
     yield put(AccountActions.SIGN_IN_EMAIL_PASSWORD.SUCCESS.create());
   } catch (error) {
-    if (checkProp(error, 'code') && error.code === ValidateError.InvalidEmail) {
-      yield put(
-        AccountActions.SIGN_IN_EMAIL_PASSWORD.FAILED.create(
-          t('errors.invalid_email'),
-          {field: 'email'},
-        ),
-      );
+    if (checkProp(error, 'code')) {
+      switch (error.code) {
+        case ValidateError.InvalidEmail:
+          yield put(
+            AccountActions.SIGN_IN_EMAIL_PASSWORD.FAILED.create(
+              t('errors.invalid_email'),
+              {field: 'email'},
+            ),
+          );
+          break;
+        case ValidateError.InvalidPassword:
+          yield put(
+            AccountActions.SIGN_IN_EMAIL_PASSWORD.FAILED.create(
+              t('errors.invalid_password'),
+              {field: 'password'},
+            ),
+          );
+          break;
+      }
     } else {
       yield put(
         AccountActions.SIGN_IN_EMAIL_PASSWORD.FAILED.create(

--- a/src/translations/locales/en.json
+++ b/src/translations/locales/en.json
@@ -160,6 +160,7 @@
     "validation_expired": "Validation expired",
     "validation_not_found": "Validation not found",
     "invalid_email": "Invalid email",
+    "invalid_password": "Invalid password",
     "invalid_ref_username": "Nickname is invalid.",
     "invalid_phone": "Invalid phone number",
     "user_disabled": "User has been disabled",

--- a/src/translations/locales/en.json.d.ts
+++ b/src/translations/locales/en.json.d.ts
@@ -109,6 +109,7 @@ export type Translations = {
   'errors.validation_expired': null;
   'errors.validation_not_found': null;
   'errors.invalid_email': null;
+  'errors.invalid_password': null;
   'errors.invalid_ref_username': null;
   'errors.invalid_phone': null;
   'errors.user_disabled': null;


### PR DESCRIPTION
Handle empty password error locally. If not handled, android crashes.