### PR TITLE
chore: improve ts, all url polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {AppRegistry} from 'react-native';
-import {App} from './src/App';
+import 'react-native-url-polyfill/auto';
 import {name as appName} from './app.json';
+import {App} from './src/App';
 
 import {LoggingWrapper} from '@services/logging';
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-native-sound": "^0.11.2",
     "react-native-store-version": "^1.4.1",
     "react-native-svg": "^13.6.0",
+    "react-native-url-polyfill": "^1.3.0",
     "react-native-view-shot": "^3.6.0",
     "react-native-vision-camera": "^2.15.4",
     "react-redux": "^8.0.5",
@@ -107,7 +108,6 @@
     "redux-saga": "^1.2.1",
     "rn-android-keyboard-adjust": "^2.1.2",
     "rn-units": "^2.0.5",
-    "url-parse": "^1.5.10",
     "vision-camera-code-scanner": "^0.2.0",
     "yarn": "^1.22.19"
   },

--- a/src/components/UserAvatarHeader/index.tsx
+++ b/src/components/UserAvatarHeader/index.tsx
@@ -5,11 +5,9 @@ import {EditableAvatar} from '@components/Avatar/EditableAvatar';
 import {LinesBackground} from '@components/LinesBackground';
 import {COLORS} from '@constants/colors';
 import {CroppedImage} from '@hooks/useActionSheetUpdateAvatar';
-import {
-  usernameWithPrefixSelector,
-  userSelector,
-} from '@store/modules/Account/selectors';
+import {userSelector} from '@store/modules/Account/selectors';
 import {font} from '@utils/styles';
+import {buildUsernameWithPrefix} from '@utils/username';
 import React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 import {useSelector} from 'react-redux';
@@ -25,7 +23,6 @@ export const UserAvatarHeader = ({
   updateAvatarLoading = false,
 }: Props) => {
   const user = useSelector(userSelector);
-  const username = useSelector(usernameWithPrefixSelector);
 
   return (
     <View style={styles.container}>
@@ -41,7 +38,7 @@ export const UserAvatarHeader = ({
         <Avatar uri={user?.profilePictureUrl} style={styles.avatarImage} />
       )}
       <Text style={styles.usernameText} numberOfLines={1}>
-        {username}
+        {buildUsernameWithPrefix(user?.username ?? '')}
       </Text>
     </View>
   );

--- a/src/navigation/components/MainTabBar/components/TabBarItem/index.tsx
+++ b/src/navigation/components/MainTabBar/components/TabBarItem/index.tsx
@@ -47,8 +47,7 @@ export const TabBarItem = ({
 
     if (!isFocused && !event.defaultPrevented) {
       // The `merge: true` option makes sure that the params inside the tab screen are preserved
-      // @ts-ignore that is basically taken from the sources
-      navigation.navigate({name: route.name, merge: true});
+      navigation.navigate({name: route.name, params: undefined, merge: true});
     }
   };
 

--- a/src/screens/HomeFlow/Home/components/Header/components/UserGreeting.tsx
+++ b/src/screens/HomeFlow/Home/components/Header/components/UserGreeting.tsx
@@ -6,11 +6,9 @@ import {MainTabsParamList} from '@navigation/Main';
 import {useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {GreetingText} from '@screens/HomeFlow/Home/components/Header/components/GreetingText';
-import {
-  usernameWithPrefixSelector,
-  userSelector,
-} from '@store/modules/Account/selectors';
+import {userSelector} from '@store/modules/Account/selectors';
 import {font} from '@utils/styles';
+import {buildUsernameWithPrefix} from '@utils/username';
 import React from 'react';
 import {ImageStyle, StyleSheet, Text, TextStyle, ViewStyle} from 'react-native';
 import Animated, {AnimatedStyleProp} from 'react-native-reanimated';
@@ -26,7 +24,6 @@ export function UserGreeting({disabled, animatedStyle}: Props) {
   const navigation =
     useNavigation<NativeStackNavigationProp<MainTabsParamList>>();
   const user = useSelector(userSelector);
-  const username = useSelector(usernameWithPrefixSelector);
   const openProfile = () => {
     navigation.navigate('ProfileTab');
   };
@@ -46,7 +43,11 @@ export function UserGreeting({disabled, animatedStyle}: Props) {
       <Animated.View style={[styles.greeting, animatedStyle]}>
         <Touchable disabled={disabled} onPress={openProfile}>
           <GreetingText />
-          {user && <Text style={styles.usernameText}>{username}</Text>}
+          {user && (
+            <Text style={styles.usernameText}>
+              {buildUsernameWithPrefix(user.username)}
+            </Text>
+          )}
         </Touchable>
       </Animated.View>
     </>

--- a/src/screens/HomeFlow/Home/components/Overview/components/AdoptionCard/index.tsx
+++ b/src/screens/HomeFlow/Home/components/Overview/components/AdoptionCard/index.tsx
@@ -113,7 +113,7 @@ export const AdoptionCard = ({isCollapsed, onPress}: AdoptionCardProps) => {
   }, [adoption]);
 
   const scrollToIndex = useCallback((index: number) => {
-    //@ts-ignore Bad types of Animated.FlatList, getNode() does not work
+    //@ts-expect-error Bad types of Animated.FlatList, getNode() does not work
     refFlatList.current?.scrollToIndex({
       animated: true,
       index,

--- a/src/screens/ProfileFlow/Profile/components/AvatarHeader/index.tsx
+++ b/src/screens/ProfileFlow/Profile/components/AvatarHeader/index.tsx
@@ -20,12 +20,11 @@ import {
   useAnimatedStyles,
 } from '@screens/ProfileFlow/Profile/components/AvatarHeader/hooks/useAnimatedStyles';
 import {useUserContactDetails} from '@screens/ProfileFlow/Profile/components/AvatarHeader/hooks/useUserContactDetails';
-import {usernameWithPrefixSelector} from '@store/modules/Account/selectors';
 import {font, mirrorTransform} from '@utils/styles';
+import {buildUsernameWithPrefix} from '@utils/username';
 import React, {memo, useState} from 'react';
 import {Image, StyleSheet, View} from 'react-native';
 import Animated, {SharedValue} from 'react-native-reanimated';
-import {useSelector} from 'react-redux';
 import {rem} from 'rn-units';
 
 const NOT_FOUND = require('../../assets/images/notFoundPlaceholder.png');
@@ -41,7 +40,6 @@ type Props = {
 
 export const AvatarHeader = memo(
   ({user, animatedIndex, isOwner, isLoading = false}: Props) => {
-    const username = useSelector(usernameWithPrefixSelector);
     const topOffset = useTopOffsetStyle();
 
     const uri = user?.profilePictureUrl;
@@ -115,7 +113,7 @@ export const AvatarHeader = memo(
               <Animated.Text
                 style={[styles.usernameText, textStyle]}
                 numberOfLines={1}>
-                {username}
+                {buildUsernameWithPrefix(user.username)}
               </Animated.Text>
             )}
           </View>

--- a/src/screens/ProfileFlow/Profile/components/UserInfo/index.tsx
+++ b/src/screens/ProfileFlow/Profile/components/UserInfo/index.tsx
@@ -2,11 +2,10 @@
 
 import {User} from '@api/user/types';
 import {LadderBar} from '@screens/ProfileFlow/Profile/components/UserInfo/LadderBar';
-import {usernameWithPrefixSelector} from '@store/modules/Account/selectors';
 import {font} from '@utils/styles';
+import {buildUsernameWithPrefix} from '@utils/username';
 import React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
-import {useSelector} from 'react-redux';
 import {rem} from 'rn-units';
 
 type Props = {
@@ -16,11 +15,10 @@ type Props = {
 export const USER_INFO_HEIGHT = rem(173);
 
 export const UserInfo = ({user}: Props) => {
-  const username = useSelector(usernameWithPrefixSelector);
   return (
     <View style={styles.container}>
       <Text style={styles.usernameText} numberOfLines={1}>
-        {user && username}
+        {buildUsernameWithPrefix(user?.username ?? '')}
       </Text>
       <View style={styles.ladderContainer}>
         {!!user && <LadderBar user={user} />}

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -136,11 +136,9 @@ export const sendPasswordResetEmail = (emailLink: string) => {
   return auth().sendPasswordResetEmail(emailLink);
 };
 
-export const isUpdateEmailLink = (
-  query: Record<string, string | undefined>,
-) => {
-  if (query && checkProp(query, 'link')) {
-    const link = query.link as String;
+export const isUpdateEmailLink = (url: URL) => {
+  const link = url.searchParams.get('link');
+  if (link) {
     return link.includes(LINKS.VERIFY_EMAIL);
   }
   return false;

--- a/src/store/modules/Account/sagas/verifyBeforeUpdateEmail.ts
+++ b/src/store/modules/Account/sagas/verifyBeforeUpdateEmail.ts
@@ -10,7 +10,6 @@ import {validateEmail} from '@utils/email';
 import {getErrorMessage} from '@utils/errors';
 import {checkProp} from '@utils/guards';
 import {call, put, select, take} from 'redux-saga/effects';
-import Url from 'url-parse';
 
 const actionCreator = AccountActions.VERIFY_BEFORE_UPDATE_EMAIL.START.create;
 
@@ -48,8 +47,10 @@ export function* verifyBeforeUpdateEmailSaga({
         case AccountActions.VERIFY_BEFORE_UPDATE_EMAIL.CONFIRM_TEMP_EMAIL
           .type: {
           try {
-            const parsedUrl = new Url(action.payload.link, true);
-            if (!parsedUrl.query.link?.includes(`email=${email}`)) {
+            const parsedUrl = new URL(action.payload.link);
+            if (
+              !parsedUrl.searchParams.get('link')?.includes(`email=${email}`)
+            ) {
               throw new Error(t('errors.general_error_message'));
             } else {
               yield call(updateEmail, user, email);

--- a/src/store/modules/Account/selectors/index.ts
+++ b/src/store/modules/Account/selectors/index.ts
@@ -3,7 +3,7 @@
 import {RegistrationProcessFinalizedStep} from '@api/user/types';
 import {isOnboardingViewedSelector} from '@store/modules/Users/selectors';
 import {RootState} from '@store/rootReducer';
-import {getLocale, isRTL} from '@translations/i18n';
+import {getLocale} from '@translations/i18n';
 import {SupportedLocale} from '@translations/localeConfig';
 import {difference} from 'lodash';
 
@@ -41,18 +41,6 @@ export const isPhoneNumberVerifiedSelector = (state: RootState) =>
 
 export const usernameSelector = (state: RootState) =>
   state.account.user?.username || '';
-
-export const usernameWithPrefixSelector = (state: RootState) => {
-  const username = usernameSelector(state);
-
-  if (username.length && isRTL) {
-    return `${username}@`;
-  } else if (username.length && !isRTL) {
-    return `@${username}`;
-  } else {
-    return username;
-  }
-};
 
 export const userInfoSelector = (state: RootState) => state.account.userInfo;
 

--- a/src/store/modules/Collections/index.ts
+++ b/src/store/modules/Collections/index.ts
@@ -5,9 +5,8 @@ import {CountryStatistics, Miner} from '@api/statistics/types';
 import {User} from '@api/user/types';
 import {createCollectionAction} from '@store/modules/Collections/actions';
 import {getInitialCollectionState} from '@store/modules/Collections/reducer';
-import {CollectionApiRequest} from '@store/modules/Collections/sagas/getCollectionSaga';
 
-export const CollectionActions = Object.freeze({
+export const CollectionActions = {
   GET_TOP_STATS_COUNTRIES: createCollectionAction<
     CountryStatistics,
     'GET_TOP_STATS_COUNTRIES'
@@ -23,7 +22,7 @@ export const CollectionActions = Object.freeze({
     'SEARCH_MINERS',
   ),
   SEARCH_USERS: createCollectionAction<User, 'SEARCH_USERS'>('SEARCH_USERS'),
-});
+} as const;
 
 export const CollectionsState = {
   topStatsCountries: getInitialCollectionState<CountryStatistics>(),
@@ -31,7 +30,7 @@ export const CollectionsState = {
   topMiners: getInitialCollectionState<Miner>(),
   minersSearch: getInitialCollectionState<Miner>(),
   usersSearch: getInitialCollectionState<User>(),
-};
+} as const;
 
 export const actionsMap = new Map<
   CollectionAction,
@@ -69,3 +68,9 @@ actionsMap.set(CollectionActions.SEARCH_USERS, {
 
 export type CollectionAction =
   typeof CollectionActions[keyof typeof CollectionActions];
+
+export type CollectionApiRequest = (params: {
+  query: string;
+  limit: number;
+  offset: number;
+}) => Promise<typeof CollectionsState[keyof typeof CollectionsState]['data']>;

--- a/src/store/modules/Collections/sagas/getCollectionSaga.ts
+++ b/src/store/modules/Collections/sagas/getCollectionSaga.ts
@@ -6,28 +6,28 @@ import {put, SagaReturnType} from 'redux-saga/effects';
 
 const DEFAULT_PAGE_SIZE = 20;
 
-export type CollectionApiRequest = (params: {
-  query: string;
-  limit: number;
-  offset: number;
-}) => Promise<unknown[]>;
+type UnionToIntersection<U> = (
+  U extends unknown ? (k: U) => void : never
+) extends (k: infer I) => void
+  ? I
+  : never;
 
-export function* getCollectionSaga(
-  action: CollectionAction,
-  {payload}: ReturnType<CollectionAction['START']['create']>,
-) {
+export function* getCollectionSaga<
+  A extends CollectionAction,
+  P extends ReturnType<A['START']['create']>,
+>(action: A, {payload}: P) {
   try {
     const {request, defaultPageSize = DEFAULT_PAGE_SIZE} =
       actionsMap.get(action) ?? {};
     const {offset, limit = defaultPageSize, query} = payload;
     if (request) {
-      const response: SagaReturnType<typeof request> = yield request({
-        query,
-        offset,
-        limit,
-      });
+      const response: UnionToIntersection<SagaReturnType<typeof request>> =
+        yield request({
+          query,
+          offset,
+          limit,
+        });
       const hasNext = response.length === limit;
-      // @ts-ignore
       yield put(action.SUCCESS.create(response, {query, offset, hasNext}));
     }
   } catch (error) {

--- a/src/store/modules/Linking/sagas/handleUrlSaga.ts
+++ b/src/store/modules/Linking/sagas/handleUrlSaga.ts
@@ -15,7 +15,6 @@ import {waitForSelector} from '@store/utils/sagas/effects';
 import {openLinkWithInAppBrowser} from '@utils/device';
 import {Linking} from 'react-native';
 import {call, put} from 'redux-saga/effects';
-import Url from 'url-parse';
 
 const actionCreator = LinkingActions.HANDLE_URL.STATE.create;
 
@@ -27,9 +26,10 @@ export function* handleUrlSaga(action: ReturnType<typeof actionCreator>) {
     return;
   }
 
-  const {path, query, isDeeplink, isUniversalLink} = parseUrl(url);
+  const {path, parsedUrl, isDeeplink, isUniversalLink} = parseUrl(url);
+  const searchParams = parsedUrl.searchParams;
 
-  if (isUpdateEmailLink(query)) {
+  if (isUpdateEmailLink(parsedUrl)) {
     yield put(
       AccountActions.VERIFY_BEFORE_UPDATE_EMAIL.CONFIRM_TEMP_EMAIL.create(url),
     );
@@ -41,17 +41,18 @@ export function* handleUrlSaga(action: ReturnType<typeof actionCreator>) {
 
   switch (path.toLowerCase()) {
     case 'browser':
-      if (query.url) {
-        const browserUrl = decodeURIComponent(query.url);
-        const parsedUrl = new Url(browserUrl);
-        if (!parsedUrl.protocol) {
+      const paramsUrl = searchParams.get('url');
+      if (paramsUrl) {
+        const browserUrl = decodeURIComponent(paramsUrl);
+        if (!new URL(browserUrl).protocol) {
           throw new Error(`Invalid url ${browserUrl}`);
         }
         openLinkWithInAppBrowser({url: browserUrl});
       }
       break;
-    case 'home':
-      switch (query.section) {
+    case 'home': {
+      const section = searchParams.get('url');
+      switch (section) {
         case 'adoption':
         default:
           navigate({
@@ -60,6 +61,7 @@ export function* handleUrlSaga(action: ReturnType<typeof actionCreator>) {
           });
       }
       break;
+    }
     case 'pre-staking':
       navigate({name: 'Staking', params: undefined});
       break;
@@ -79,22 +81,20 @@ export function* handleUrlSaga(action: ReturnType<typeof actionCreator>) {
       navigate({name: 'NewsTab', params: undefined});
       break;
     case 'profile':
-      // TODO: temp profile disabling
-      if (false) {
-        const userId = query.userId ?? '';
-        switch (query.section) {
-          case 'roles':
-            navigate({name: 'Roles', params: {userId}});
-            break;
-          case 'badges':
-            navigate({name: 'Badges', params: {userId}});
-            break;
-          default:
-            navigate({
-              name: 'UserProfile',
-              params: {userId},
-            });
-        }
+      const userId = searchParams.get('userId') ?? '';
+      const section = searchParams.get('section');
+      switch (section) {
+        case 'roles':
+          navigate({name: 'Roles', params: {userId}});
+          break;
+        case 'badges':
+          navigate({name: 'Badges', params: {userId}});
+          break;
+        default:
+          navigate({
+            name: 'UserProfile',
+            params: {userId},
+          });
       }
       break;
     case 'claim-daily-bonus':
@@ -115,10 +115,12 @@ export function* handleUrlSaga(action: ReturnType<typeof actionCreator>) {
   }
 }
 
-const parseUrl = (url: string) => {
-  const parsed = new Url(url, true);
-  const isDeeplink = parsed.protocol.includes(ENV.DEEPLINK_SCHEME ?? '');
-  const isUniversalLink = parsed.host === ENV.DEEPLINK_DOMAIN;
-  const path = isDeeplink ? parsed.host : parsed.pathname.replace('/', '');
-  return {isDeeplink, isUniversalLink, path, ...parsed};
+export const parseUrl = (url: string) => {
+  const parsedUrl = new URL(url);
+  const isDeeplink = parsedUrl.protocol.includes(ENV.DEEPLINK_SCHEME ?? '');
+  const isUniversalLink = parsedUrl.host === ENV.DEEPLINK_DOMAIN;
+  const path = isDeeplink
+    ? parsedUrl.host
+    : parsedUrl.pathname.replace('/', '');
+  return {isDeeplink, isUniversalLink, path, parsedUrl};
 };

--- a/src/store/utils/actions/createAction.ts
+++ b/src/store/utils/actions/createAction.ts
@@ -42,7 +42,7 @@ export type StartActionFactories = ActionFactories<
   {START: PayloadFunc | boolean}
 >;
 
-type ActionObject<
+export type ActionObject<
   ActionPartType,
   T extends StructureType,
   K extends keyof T,

--- a/src/store/utils/sagas/effects.ts
+++ b/src/store/utils/sagas/effects.ts
@@ -26,8 +26,7 @@ export function takeLatestEveryUnique<
     const tasksSet = new Map();
 
     while (true) {
-      // @ts-ignore
-      const action = yield take(patternOrChannel);
+      const action: any = yield take(patternOrChannel);
       const {id} = action;
 
       if (tasksSet.has(id)) {
@@ -57,8 +56,7 @@ export function takeLeadingEveryUnique<
     const tasksSet = new Map();
 
     while (true) {
-      // @ts-ignore
-      const action = yield take(patternOrChannel);
+      const action: any = yield take(patternOrChannel);
       const {id} = action;
       if (!tasksSet.has(id)) {
         yield fork(function* () {

--- a/src/utils/username.ts
+++ b/src/utils/username.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {LINKS} from '@constants/links';
+import {isRTL} from '@translations/i18n';
 
 export const removeInvalidUsernameCharacters = (username: string) => {
   return username.replace(/[^a-zA-Z0-9.]/g, '');
@@ -16,3 +17,11 @@ export const buildUsernameLink = (username: string) =>
 
 export const getUsernameFromUsernameLink = (usernameLink: string) =>
   usernameLink.match(`${LINKS.MAIN}@(.+)`)?.[1];
+
+export const buildUsernameWithPrefix = (username: string) => {
+  if (username.length) {
+    return isRTL ? `${username}@` : `@${username}`;
+  } else {
+    return username;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,7 +2991,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.5.0:
+buffer@^5.4.3, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -8416,6 +8416,13 @@ react-native-swipe-gestures@^1.0.5:
   resolved "https://registry.yarnpkg.com/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz#a172cb0f3e7478ccd681fd36b8bfbcdd098bde7c"
   integrity sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==
 
+react-native-url-polyfill@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz#c1763de0f2a8c22cc3e959b654c8790622b6ef6a"
+  integrity sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==
+  dependencies:
+    whatwg-url-without-unicode "8.0.0-3"
+
 react-native-view-shot@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.6.0.tgz#2c5febd03cb1effb9923372b29aed227c680d9fd"
@@ -10050,7 +10057,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
 
-url-parse@^1.5.10, url-parse@^1.5.3:
+url-parse@^1.5.3:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
@@ -10200,6 +10207,11 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
+
 websocket-driver@>=0.5.1:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
@@ -10218,6 +10230,15 @@ whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
+whatwg-url-without-unicode@8.0.0-3:
+  version "8.0.0-3"
+  resolved "https://registry.yarnpkg.com/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz#ab6df4bf6caaa6c85a59f6e82c026151d4bb376b"
+  integrity sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==
+  dependencies:
+    buffer "^5.4.3"
+    punycode "^2.1.1"
+    webidl-conversions "^5.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
* Some `ts-ignores` are fixed, some just changed to something less dangerous:
E.g. unlike @ts-ignore, @ts-expect-error throws an error on ts-lint check if error is not there anymore. So at some point the types for `Animated.FlatList` will be fixes, we'll know about it and remove the comment completely

* Use `react-native-url-polyfill` instead of custom `url-parse` lib since polyfill uses build in react-native modules to deal with urls instead of parsing using regexps in `url-parse`. And it is easier to switch from a polyfill if at some point RN adds the support out of the box

* Fix the issue when on other user's profile the username of the main user is displayed