### PR TITLE
fix: stop get email code confirm only on known errors

### DIFF
--- a/src/screens/AuthFlow/ConfirmEmailCode/hooks/useConfirmEmailCode.ts
+++ b/src/screens/AuthFlow/ConfirmEmailCode/hooks/useConfirmEmailCode.ts
@@ -4,15 +4,11 @@ import {AuthStackParamList} from '@navigation/Auth';
 import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {AccountActions} from '@store/modules/Account/actions';
-import {
-  failedReasonSelector,
-  processStatusForActionSelector,
-} from '@store/modules/UtilityProcessStatuses/selectors';
+import {failedReasonSelector} from '@store/modules/UtilityProcessStatuses/selectors';
 import {
   emailVerificationCodeSelector,
   temporaryEmailSelector,
 } from '@store/modules/Validation/selectors';
-import {RootState} from '@store/rootReducer';
 import {useCallback, useEffect} from 'react';
 import {BackHandler} from 'react-native';
 import {useDispatch, useSelector} from 'react-redux';
@@ -25,17 +21,11 @@ export const useConfirmEmailCode = () => {
   const code = useSelector(emailVerificationCodeSelector, () => true);
 
   const validateError = useSelector(
-    failedReasonSelector.bind(null, AccountActions.SIGN_IN_EMAIL_LINK),
-  );
-
-  const validateLoading = useSelector(
-    (state: RootState) =>
-      processStatusForActionSelector(state, AccountActions.SIGN_IN_EMAIL_LINK)
-        ?.status === 'CONFIRM_TEMP_EMAIL',
+    failedReasonSelector.bind(null, AccountActions.SIGN_IN_EMAIL_CODE),
   );
 
   const goBack = () => {
-    dispatch(AccountActions.SIGN_IN_EMAIL_LINK.RESET.create());
+    dispatch(AccountActions.SIGN_IN_EMAIL_CODE.RESET.create());
   };
 
   useFocusEffect(
@@ -43,7 +33,7 @@ export const useConfirmEmailCode = () => {
       const subscription = BackHandler.addEventListener(
         'hardwareBackPress',
         () => {
-          dispatch(AccountActions.SIGN_IN_EMAIL_LINK.RESET.create());
+          dispatch(AccountActions.SIGN_IN_EMAIL_CODE.RESET.create());
           return true;
         },
       );
@@ -53,7 +43,7 @@ export const useConfirmEmailCode = () => {
 
   useEffect(() => {
     if (validateError) {
-      navigation.replace('InvalidLink');
+      navigation.goBack();
     }
   }, [validateError, navigation]);
 
@@ -61,7 +51,6 @@ export const useConfirmEmailCode = () => {
     email,
     code,
     validateError,
-    validateLoading,
     goBack,
   };
 };

--- a/src/screens/AuthFlow/ConfirmEmailCode/index.tsx
+++ b/src/screens/AuthFlow/ConfirmEmailCode/index.tsx
@@ -2,7 +2,6 @@
 
 import {BackButton} from '@components/Buttons/BackButton';
 import {EmailCode} from '@components/Forms/components/EmailCode';
-import {FullScreenLoading} from '@components/FullScreenLoading';
 import {LottieView} from '@components/LottieView';
 import {PrivacyTerms} from '@components/PrivacyTerms';
 import {Touchable} from '@components/Touchable';
@@ -20,7 +19,7 @@ import {rem} from 'rn-units';
 
 export const ConfirmEmailCode = () => {
   useFocusStatusBar({style: 'light-content'});
-  const {email, code, validateLoading, goBack} = useConfirmEmailCode();
+  const {email, code, goBack} = useConfirmEmailCode();
 
   return (
     <View style={commonStyles.flexOne}>
@@ -56,7 +55,6 @@ export const ConfirmEmailCode = () => {
         </View>
         <PrivacyTerms />
       </View>
-      {validateLoading && <FullScreenLoading />}
     </View>
   );
 };


### PR DESCRIPTION
* don't stop calling getConfirmationStatus on unknown errors
* process confirm code errors on UI side properly