### PR TITLE
fix: sentry errors

### DIFF
--- a/src/api/client/interceptors/response.ts
+++ b/src/api/client/interceptors/response.ts
@@ -90,6 +90,10 @@ const refreshTokenConcurrently = async <T>(error: T) => {
       return null;
     }
     throw error;
+  } finally {
+    if (tokenRefreshPromise) {
+      tokenRefreshPromise = null;
+    }
   }
 };
 

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -201,10 +201,22 @@ export const clearPersistedAuthTokens = async () => {
   }
 };
 
-export const refreshAuthToken = async (currentToken: AuthToken) => {
+export const refreshAuthToken = async (
+  currentToken: AuthToken,
+  {
+    /**
+     * Force refresh firebase token regardless of token expiration.
+     *  Might be used when updated user claims are needed to be fetched.
+     *  if forceUpdate->true, getIdTokenResult triggers onUserChanged upon completion
+     */
+    forceUpdate = false,
+  }: {forceUpdate?: boolean} = {},
+) => {
   switch (currentToken.issuer) {
     case 'firebase':
-      const newFirebaseToken = await auth().currentUser?.getIdTokenResult(true);
+      const newFirebaseToken = await auth().currentUser?.getIdTokenResult(
+        forceUpdate,
+      );
       if (!newFirebaseToken) {
         return null;
       }

--- a/src/services/auth/signin/google.ts
+++ b/src/services/auth/signin/google.ts
@@ -5,7 +5,7 @@ import {
   GoogleSignin,
   statusCodes,
 } from '@react-native-google-signin/google-signin';
-import {SocialSignInMethod} from '@services/auth/signin/types';
+import {AuthError, SocialSignInMethod} from '@services/auth/signin/types';
 import {t} from '@translations/i18n';
 import {checkProp} from '@utils/guards';
 import {removeInvalidUsernameCharacters} from '@utils/username';
@@ -45,7 +45,11 @@ export const startGoogleSignIn: SocialSignInMethod<{
         case statusCodes.IN_PROGRESS:
           throw new Error(t('errors.auth_in_progress'));
         case statusCodes.PLAY_SERVICES_NOT_AVAILABLE:
-          throw new Error(t('errors.google_play_services_not_available'));
+        case 16: // https://developers.google.com/android/reference/com/google/android/gms/common/ConnectionResult#API_UNAVAILABLE
+          throw {
+            code: AuthError.PlayServicesNotAvailable,
+            message: t('errors.google_play_services_not_available'),
+          };
         default:
           throw new Error(
             t('errors.unknown_error_with_code', {code: String(error.code)}),

--- a/src/services/auth/signin/types.ts
+++ b/src/services/auth/signin/types.ts
@@ -16,3 +16,7 @@ export type SocialSignInMethod<T> = () => Promise<
 >;
 
 export type SocialSignInProvider = 'apple' | 'google' | 'facebook' | 'twitter';
+
+export enum AuthError {
+  PlayServicesNotAvailable = 'PlayServicesNotAvailable',
+}

--- a/src/services/firebase/index.tsx
+++ b/src/services/firebase/index.tsx
@@ -7,10 +7,10 @@ import {isIOS} from 'rn-units';
 export const isPlayServicesAvailable =
   firebaseApp.utils().playServicesAvailability.isAvailable;
 
-export const getFcmToken = () => {
+export const getFcmToken = async () => {
   try {
     if (isIOS || isPlayServicesAvailable) {
-      return messaging().getToken();
+      return await messaging().getToken();
     }
     return '';
   } catch (error) {

--- a/src/services/keychain/index.ts
+++ b/src/services/keychain/index.ts
@@ -2,14 +2,23 @@
 
 import * as Keychain from 'react-native-keychain';
 
+/**
+ * Using FB storage because with a default one, on some devices
+ * "Could not decrypt data with alias: ..." error is thrown.
+ * https://github.com/oblador/react-native-keychain/issues/567
+ */
 export const setSecureValue = (key: string, value: string) => {
   return Keychain.setGenericPassword(key, value, {
     service: key,
+    storage: Keychain.STORAGE_TYPE.FB,
   });
 };
 
 export const getSecureValue = async (key: string) => {
-  const result = await Keychain.getGenericPassword({service: key});
+  const result = await Keychain.getGenericPassword({
+    service: key,
+    storage: Keychain.STORAGE_TYPE.FB,
+  });
   if (result) {
     return result.password;
   }

--- a/src/store/modules/Account/sagas/signInSocial.ts
+++ b/src/store/modules/Account/sagas/signInSocial.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {signInWithProvider} from '@services/auth';
+import {AuthError} from '@services/auth/signin/types';
 import {AccountActions} from '@store/modules/Account/actions';
 import {getErrorMessage} from '@utils/errors';
+import {checkProp} from '@utils/guards';
 import {call, put, SagaReturnType} from 'redux-saga/effects';
 
 export function* signInSocialSaga(
@@ -24,6 +26,13 @@ export function* signInSocialSaga(
     yield put(
       AccountActions.SIGN_IN_SOCIAL.FAILED.create(getErrorMessage(error)),
     );
-    throw error;
+    if (
+      !(
+        checkProp(error, 'code') &&
+        error.code === AuthError.PlayServicesNotAvailable
+      )
+    ) {
+      throw error;
+    }
   }
 }

--- a/src/store/modules/Account/sagas/userStateChange.ts
+++ b/src/store/modules/Account/sagas/userStateChange.ts
@@ -59,7 +59,9 @@ export function* userStateChangeSaga() {
           email: authenticatedUser.email,
           phoneNumber: authenticatedUser.phoneNumber,
         });
-        yield call(refreshAuthToken, authenticatedUser.token);
+        yield call(refreshAuthToken, authenticatedUser.token, {
+          forceUpdate: true,
+        });
         /**
          * In case of firebase, userStateChange is triggered by the lib,
          *  because of the forceRefresh flag.

--- a/src/store/modules/Analytics/constants.ts
+++ b/src/store/modules/Analytics/constants.ts
@@ -37,6 +37,7 @@ export const EVENT_NAMES = {
   CHANGE_PROFILE_PICTURE: 'Change Profile Picture',
   SHARE_PROFILE_USERNAME: 'Share Telegram Username',
   PING: 'Ping',
+  RATE: 'Rate',
 } as const;
 
 const NOT_TRACKABLE_SCREENS = new Set([

--- a/src/store/modules/AppCommon/sagas/index.ts
+++ b/src/store/modules/AppCommon/sagas/index.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {AccountActions} from '@store/modules/Account/actions';
+import {AppCommonActions} from '@store/modules/AppCommon/actions';
 import {appInitializedHandlerSaga} from '@store/modules/AppCommon/sagas/appInitializedHandler';
 import {appLoadedHandlerSaga} from '@store/modules/AppCommon/sagas/appLoadedHandlerSaga';
 import {intervalUpdatesSaga} from '@store/modules/AppCommon/sagas/intervalUpdates';
@@ -10,7 +11,10 @@ export const appCommonWatchers = [
   fork(appInitializedHandlerSaga),
   fork(appLoadedHandlerSaga),
   takeLatest(
-    AccountActions.USER_STATE_CHANGE.SUCCESS.type,
+    [
+      AccountActions.USER_STATE_CHANGE.SUCCESS.type,
+      AppCommonActions.APP_STATE_CHANGE.STATE.type,
+    ],
     intervalUpdatesSaga,
   ),
 ];

--- a/src/store/modules/AppCommon/sagas/intervalUpdates.ts
+++ b/src/store/modules/AppCommon/sagas/intervalUpdates.ts
@@ -6,6 +6,7 @@ import {
   isRegistrationCompleteSelector,
 } from '@store/modules/Account/selectors';
 import {AppCommonActions} from '@store/modules/AppCommon/actions';
+import {isAppActiveSelector} from '@store/modules/AppCommon/selectors';
 import {waitForSelector} from '@store/utils/sagas/effects';
 import {call, delay, put, select} from 'redux-saga/effects';
 
@@ -14,7 +15,11 @@ export function* intervalUpdatesSaga() {
     isAuthorizedSelector,
   );
 
-  if (isAuthorized) {
+  const isAppActive: ReturnType<typeof isAuthorizedSelector> = yield select(
+    isAppActiveSelector,
+  );
+
+  if (isAuthorized && isAppActive) {
     yield call(waitForSelector, isRegistrationCompleteSelector);
     while (true) {
       yield delay(APP_AUTO_UPDATE_INTERVAL_SEC * 1000);

--- a/src/store/modules/RateApp/sagas/showRateAppSaga.ts
+++ b/src/store/modules/RateApp/sagas/showRateAppSaga.ts
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: ice License 1.0
 
 import {rateApp} from '@services/rateApp';
+import {
+  AnalyticsEventLogger,
+  EVENT_NAMES,
+} from '@store/modules/Analytics/constants';
 import {RateAppActions} from '@store/modules/RateApp/actions';
 import {call, put, SagaReturnType} from 'redux-saga/effects';
 
@@ -10,12 +14,18 @@ export function* showRateAppSaga() {
 
     if (rateAppResult) {
       yield put(RateAppActions.SHOW_RATE_APP.SUCCESS.create());
+      yield call(AnalyticsEventLogger.trackEvent, {
+        eventName: EVENT_NAMES.RATE,
+      });
     } else {
       yield put(RateAppActions.SHOW_RATE_APP.FAILED.create());
     }
   } catch (error) {
+    /**
+     * There might be a variety of reasons for errors that we can do nothing about
+     * e.g. when the app is installed not from GP / when activity is null / ...
+     * So ignoring them (do not throw the error here)
+     */
     yield put(RateAppActions.SHOW_RATE_APP.FAILED.create());
-
-    throw error;
   }
 }


### PR DESCRIPTION
* clean up refreshTokenPromise to fix a case when all the requests are failed because of expired token and token is not refreshed because something (e.g. network error) happened on the last refresh attempt
* change persisted storage to FB - that should fix the issue on some devices "Could not decrypt data with alias: custom_auth_token"
* stop interval updates when app goes background
* properly handle getFcmToken errors
* ignore unimportant errors in checkAppUpdates / rateTheApp sagas
* stop interval updates when app goes background
* ignore background sync -> update account errors (network errors)
* process google sign in error 16 (google services unavailable)